### PR TITLE
Add ser-diff CLI and XML diff automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Ruff
+        run: python -m ruff check serdiff tests
+      - name: Black
+        run: python -m black --check serdiff tests
+      - name: Pytest
+        run: python -m pytest
+      - name: Demo artifacts
+        run: make demo
+      - name: Upload reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: demo-reports-${{ matrix.python-version }}
+          path: reports/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+reports/demo_*
+.cache/
+.pytest_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SER Snapshot Diff Automation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: venv fmt lint test demo clean
+
+VENV?=.venv
+PYTHON?=python3
+
+venv:
+$(PYTHON) -m venv $(VENV)
+$(VENV)/bin/pip install --upgrade pip
+$(VENV)/bin/pip install -e .[dev]
+
+fmt:
+$(PYTHON) -m black serdiff tests
+$(PYTHON) -m ruff check serdiff tests --fix
+
+lint:
+$(PYTHON) -m ruff check serdiff tests
+
+test:
+$(PYTHON) -m pytest
+
+demo:
+ser-diff --before samples/SER_before.xml --after samples/SER_after.xml --table SER --out-prefix reports/demo_SER --jira DEMO-SER
+ser-diff --before samples/EXPOSURE_before.xml --after samples/EXPOSURE_after.xml --table EXPOSURE --out-prefix reports/demo_EXPOSURE --jira DEMO-EXP
+
+clean:
+rm -rf $(VENV)
+rm -rf reports/demo_*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# SER Snapshot Diff Automation
+
+`ser-diff` is a lightweight, production-ready CLI for diffing PolicyCenter system-table XML exports. It specialises in Simple Exposure Rates (SER) and Exposure Types tables, producing JSON/CSV artifacts that can be attached directly to Jira and change tickets.
+
+## Features
+
+- Streaming XML reader powered by `xml.etree.ElementTree.iterparse` for large files.
+- Presets for SER and Exposure Types tables plus a fully custom mode.
+- Field-level diffing with auditable JSON + CSV outputs.
+- Threshold and partner guard rails for change management.
+- Ready for CI: linting, tests, and demo artifact generation.
+
+## Installation
+
+Use a virtual environment or `pipx`:
+
+```bash
+pipx install .
+# or
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Quick Start
+
+```bash
+ser-diff \
+  --before exports/Prod_BEFORE_Import_CASSimpleExpsRateTbl_Ext.xml \
+  --after  exports/Prod_AFTER_Import_CASSimpleExpsRateTbl_Ext.xml  \
+  --table SER \
+  --out-prefix reports/MOBPXD-1223_Prod_SER_diff \
+  --jira MOBPXD-1223 \
+  --expected-partners Uber \
+  --max-added 50 --max-removed 10
+
+ser-diff \
+  --before exports/Prod_BEFORE_ExposureTypes.xml \
+  --after  exports/Prod_AFTER_ExposureTypes.xml  \
+  --table EXPOSURE \
+  --out-prefix reports/MOBPXD-1213_Prod_Exposure_diff \
+  --jira MOBPXD-1213
+```
+
+### Custom tables
+
+```bash
+ser-diff \
+  --before before.xml \
+  --after after.xml \
+  --record-path .//CustomRecord \
+  --key PublicID --key Partner \
+  --fields PublicID,Partner,State,Factor
+```
+
+## SOP Snippet (Standard Change)
+
+1. Export BEFORE (SER) from PolicyCenter.
+2. Import the Jira-provided XML (e.g. `MOBPXD-1213_SerImport.xml`).
+3. Export AFTER (SER).
+4. Run the diff:
+   ```bash
+   ser-diff --before BEFORE.xml --after AFTER.xml --table SER \
+     --out-prefix reports/MOBPXD-1213_Prod_SER_diff --jira MOBPXD-1213
+   ```
+5. Review the console summary.
+6. Attach the generated JSON/CSV files to Jira and the Change ticket.
+7. Proceed only if summary counts and thresholds are green.
+
+## Thresholds and Partners
+
+- `--max-added` / `--max-removed` enforce safety rails. Set `--fail-on-unexpected` to exit with status `2` if the gates are breached (reports are still written).
+- `--expected-partners` validates the `Partner` column. Unexpected partners are highlighted and can fail the run with `--fail-on-unexpected`.
+
+## Performance Notes
+
+The XML reader uses `iterparse` to stream records and clear elements once processed. This keeps memory usage flat even for multi-gigabyte exports. Keys are validated for duplicates, and composite keys are supported for SER when `PublicID` is missing.
+
+## Demo Data
+
+Sample SER and Exposure XML files live in `samples/`. Run `make demo` to generate reference reports in `reports/`.
+
+## Development
+
+```bash
+make venv      # create a virtual environment with dev deps
+make fmt       # run black + ruff --fix
+make lint      # run ruff linting
+make test      # run pytest
+make demo      # build sample reports
+```
+
+CI runs linting, tests, and demo generation on Python 3.10 and 3.12. Reports are uploaded as artifacts for traceability.
+
+## License
+
+MIT License. See [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+name = "ser-snapshot-diff"
+version = "0.1.0"
+description = "CLI for diffing PolicyCenter SER and Exposure Type XML exports"
+authors = [{name = "SER Snapshot Diff Automation", email = "eng@example.com"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+ser-diff = "serdiff.cli:main"
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "ruff>=0.1",
+  "black>=23.7",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["."]
+
+[tool.black]
+target-version = ["py310"]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "C4", "SIM", "N"]
+ignore = ["E501"]
+per-file-ignores = {"tests/*" = ["S101"]}

--- a/reports/sample_EXPOSURE_SAMPLE-EXP.json
+++ b/reports/sample_EXPOSURE_SAMPLE-EXP.json
@@ -1,0 +1,108 @@
+{
+  "summary": {
+    "added": 1,
+    "removed": 1,
+    "updated": 1,
+    "total_before": 2,
+    "total_after": 2,
+    "total_changed": 3
+  },
+  "meta": {
+    "jira": "SAMPLE-EXP",
+    "generated_at": "2025-10-06T18:07:38.063248+00:00",
+    "table": "EXPOSURE",
+    "before_file": {
+      "path": "samples/EXPOSURE_before.xml",
+      "sha256": "b5608557888556ed744629e84a6ad28939dc02baa9b484e9d6f7775bfbbf1881"
+    },
+    "after_file": {
+      "path": "samples/EXPOSURE_after.xml",
+      "sha256": "0aa43db503b82d256b99078fda1988baee38f36fe1ae33d4a0458b98c6563bbb"
+    },
+    "record_path": ".//ExposureType",
+    "fields": [
+      "PublicID",
+      "ExposureCode",
+      "Partner",
+      "State",
+      "EffectiveDate",
+      "ExpirationDate"
+    ],
+    "key_fields": [
+      [
+        "PublicID"
+      ]
+    ],
+    "partners_detected": [
+      "DoorDash",
+      "HelloFresh",
+      "Uber"
+    ],
+    "expected_partners": []
+  },
+  "added": [
+    {
+      "key": "PublicID=EXP-DOORDASH-01",
+      "key_fields": [
+        "PublicID"
+      ],
+      "before": {},
+      "after": {
+        "PublicID": "EXP-DOORDASH-01",
+        "ExposureCode": "DDR",
+        "Partner": "DoorDash",
+        "State": "TX",
+        "EffectiveDate": "2023-03-01",
+        "ExpirationDate": "2023-12-31"
+      }
+    }
+  ],
+  "removed": [
+    {
+      "key": "PublicID=EXP-HELLO-01",
+      "key_fields": [
+        "PublicID"
+      ],
+      "before": {
+        "PublicID": "EXP-HELLO-01",
+        "ExposureCode": "HFR",
+        "Partner": "HelloFresh",
+        "State": "CA",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31"
+      },
+      "after": {}
+    }
+  ],
+  "updated": [
+    {
+      "key": "PublicID=EXP-UBER-01",
+      "key_fields": [
+        "PublicID"
+      ],
+      "changes": {
+        "State": {
+          "before": "NY",
+          "after": "NJ"
+        }
+      },
+      "before": {
+        "PublicID": "EXP-UBER-01",
+        "ExposureCode": "UBR",
+        "Partner": "Uber",
+        "State": "NY",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31"
+      },
+      "after": {
+        "PublicID": "EXP-UBER-01",
+        "ExposureCode": "UBR",
+        "Partner": "Uber",
+        "State": "NJ",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31"
+      }
+    }
+  ],
+  "unexpected_partners": []
+}

--- a/reports/sample_EXPOSURE_SAMPLE-EXP_added.csv
+++ b/reports/sample_EXPOSURE_SAMPLE-EXP_added.csv
@@ -1,0 +1,2 @@
+key,key_fields,before,after
+PublicID=EXP-DOORDASH-01,['PublicID'],{},"{""EffectiveDate"": ""2023-03-01"", ""ExpirationDate"": ""2023-12-31"", ""ExposureCode"": ""DDR"", ""Partner"": ""DoorDash"", ""PublicID"": ""EXP-DOORDASH-01"", ""State"": ""TX""}"

--- a/reports/sample_EXPOSURE_SAMPLE-EXP_removed.csv
+++ b/reports/sample_EXPOSURE_SAMPLE-EXP_removed.csv
@@ -1,0 +1,2 @@
+key,key_fields,before,after
+PublicID=EXP-HELLO-01,['PublicID'],"{""EffectiveDate"": ""2023-01-01"", ""ExpirationDate"": ""2023-12-31"", ""ExposureCode"": ""HFR"", ""Partner"": ""HelloFresh"", ""PublicID"": ""EXP-HELLO-01"", ""State"": ""CA""}",{}

--- a/reports/sample_EXPOSURE_SAMPLE-EXP_summary.csv
+++ b/reports/sample_EXPOSURE_SAMPLE-EXP_summary.csv
@@ -1,0 +1,8 @@
+metric,value
+added,1
+removed,1
+updated,1
+total_before,2
+total_after,2
+total_changed,3
+unexpected_partners,

--- a/reports/sample_EXPOSURE_SAMPLE-EXP_updated.csv
+++ b/reports/sample_EXPOSURE_SAMPLE-EXP_updated.csv
@@ -1,0 +1,2 @@
+key,field,before,after
+PublicID=EXP-UBER-01,State,NY,NJ

--- a/reports/sample_SER_SAMPLE-SER.json
+++ b/reports/sample_SER_SAMPLE-SER.json
@@ -1,0 +1,120 @@
+{
+  "summary": {
+    "added": 1,
+    "removed": 1,
+    "updated": 1,
+    "total_before": 3,
+    "total_after": 3,
+    "total_changed": 3
+  },
+  "meta": {
+    "jira": "SAMPLE-SER",
+    "generated_at": "2025-10-06T18:07:35.164535+00:00",
+    "table": "SER",
+    "before_file": {
+      "path": "samples/SER_before.xml",
+      "sha256": "c189ad6cfd4c4f68de6aa6e57b10b0eefb628381eb67055448aaab5441a429f5"
+    },
+    "after_file": {
+      "path": "samples/SER_after.xml",
+      "sha256": "c0dd40920017f5e947c438b7be861d7c3a2391e415d27fc48ff1b9c12e8a424e"
+    },
+    "record_path": ".//Rate",
+    "fields": [
+      "PublicID",
+      "Partner",
+      "State",
+      "AgeBand",
+      "EffectiveDate",
+      "ExpirationDate",
+      "Factor"
+    ],
+    "key_fields": [
+      [
+        "PublicID"
+      ],
+      [
+        "Partner",
+        "State",
+        "AgeBand",
+        "EffectiveDate"
+      ]
+    ],
+    "partners_detected": [
+      "DoorDash",
+      "HelloFresh",
+      "Marsh Risk",
+      "Uber"
+    ],
+    "expected_partners": []
+  },
+  "added": [
+    {
+      "key": "PublicID=SER-MARSH-IL",
+      "key_fields": [
+        "PublicID"
+      ],
+      "before": {},
+      "after": {
+        "PublicID": "SER-MARSH-IL",
+        "Partner": "Marsh Risk",
+        "State": "IL",
+        "AgeBand": "Adult",
+        "EffectiveDate": "2023-06-01",
+        "ExpirationDate": "2023-12-31",
+        "Factor": "1.40"
+      }
+    }
+  ],
+  "removed": [
+    {
+      "key": "PublicID=SER-HELLO-CA",
+      "key_fields": [
+        "PublicID"
+      ],
+      "before": {
+        "PublicID": "SER-HELLO-CA",
+        "Partner": "HelloFresh",
+        "State": "CA",
+        "AgeBand": "Adult",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31",
+        "Factor": "0.95"
+      },
+      "after": {}
+    }
+  ],
+  "updated": [
+    {
+      "key": "PublicID=SER-UBER-NY",
+      "key_fields": [
+        "PublicID"
+      ],
+      "changes": {
+        "Factor": {
+          "before": "1.15",
+          "after": "1.25"
+        }
+      },
+      "before": {
+        "PublicID": "SER-UBER-NY",
+        "Partner": "Uber",
+        "State": "NY",
+        "AgeBand": "Adult",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31",
+        "Factor": "1.15"
+      },
+      "after": {
+        "PublicID": "SER-UBER-NY",
+        "Partner": "Uber",
+        "State": "NY",
+        "AgeBand": "Adult",
+        "EffectiveDate": "2023-01-01",
+        "ExpirationDate": "2023-12-31",
+        "Factor": "1.25"
+      }
+    }
+  ],
+  "unexpected_partners": []
+}

--- a/reports/sample_SER_SAMPLE-SER_added.csv
+++ b/reports/sample_SER_SAMPLE-SER_added.csv
@@ -1,0 +1,2 @@
+key,key_fields,before,after
+PublicID=SER-MARSH-IL,['PublicID'],{},"{""AgeBand"": ""Adult"", ""EffectiveDate"": ""2023-06-01"", ""ExpirationDate"": ""2023-12-31"", ""Factor"": ""1.40"", ""Partner"": ""Marsh Risk"", ""PublicID"": ""SER-MARSH-IL"", ""State"": ""IL""}"

--- a/reports/sample_SER_SAMPLE-SER_removed.csv
+++ b/reports/sample_SER_SAMPLE-SER_removed.csv
@@ -1,0 +1,2 @@
+key,key_fields,before,after
+PublicID=SER-HELLO-CA,['PublicID'],"{""AgeBand"": ""Adult"", ""EffectiveDate"": ""2023-01-01"", ""ExpirationDate"": ""2023-12-31"", ""Factor"": ""0.95"", ""Partner"": ""HelloFresh"", ""PublicID"": ""SER-HELLO-CA"", ""State"": ""CA""}",{}

--- a/reports/sample_SER_SAMPLE-SER_summary.csv
+++ b/reports/sample_SER_SAMPLE-SER_summary.csv
@@ -1,0 +1,8 @@
+metric,value
+added,1
+removed,1
+updated,1
+total_before,3
+total_after,3
+total_changed,3
+unexpected_partners,

--- a/reports/sample_SER_SAMPLE-SER_updated.csv
+++ b/reports/sample_SER_SAMPLE-SER_updated.csv
@@ -1,0 +1,2 @@
+key,field,before,after
+PublicID=SER-UBER-NY,Factor,1.15,1.25

--- a/samples/EXPOSURE_after.xml
+++ b/samples/EXPOSURE_after.xml
@@ -1,0 +1,18 @@
+<ExposureTypes>
+  <ExposureType>
+    <PublicID>EXP-UBER-01</PublicID>
+    <ExposureCode>UBR</ExposureCode>
+    <Partner>Uber</Partner>
+    <State>NJ</State>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+  </ExposureType>
+  <ExposureType>
+    <PublicID>EXP-DOORDASH-01</PublicID>
+    <ExposureCode>DDR</ExposureCode>
+    <Partner>DoorDash</Partner>
+    <State>TX</State>
+    <EffectiveDate>2023-03-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+  </ExposureType>
+</ExposureTypes>

--- a/samples/EXPOSURE_before.xml
+++ b/samples/EXPOSURE_before.xml
@@ -1,0 +1,18 @@
+<ExposureTypes>
+  <ExposureType>
+    <PublicID>EXP-UBER-01</PublicID>
+    <ExposureCode>UBR</ExposureCode>
+    <Partner>Uber</Partner>
+    <State>NY</State>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+  </ExposureType>
+  <ExposureType>
+    <PublicID>EXP-HELLO-01</PublicID>
+    <ExposureCode>HFR</ExposureCode>
+    <Partner>HelloFresh</Partner>
+    <State>CA</State>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+  </ExposureType>
+</ExposureTypes>

--- a/samples/SER_after.xml
+++ b/samples/SER_after.xml
@@ -1,0 +1,28 @@
+<SimpleExposureRates>
+  <Rate>
+    <PublicID>SER-UBER-NY</PublicID>
+    <Partner>Uber</Partner>
+    <State>NY</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>1.25</Factor>
+  </Rate>
+  <Rate>
+    <Partner>DoorDash</Partner>
+    <State>TX</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>1.05</Factor>
+  </Rate>
+  <Rate>
+    <PublicID>SER-MARSH-IL</PublicID>
+    <Partner>Marsh Risk</Partner>
+    <State>IL</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-06-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>1.40</Factor>
+  </Rate>
+</SimpleExposureRates>

--- a/samples/SER_before.xml
+++ b/samples/SER_before.xml
@@ -1,0 +1,28 @@
+<SimpleExposureRates>
+  <Rate>
+    <PublicID>SER-UBER-NY</PublicID>
+    <Partner>Uber</Partner>
+    <State>NY</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>1.15</Factor>
+  </Rate>
+  <Rate>
+    <PublicID>SER-HELLO-CA</PublicID>
+    <Partner>HelloFresh</Partner>
+    <State>CA</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>0.95</Factor>
+  </Rate>
+  <Rate>
+    <Partner>DoorDash</Partner>
+    <State>TX</State>
+    <AgeBand>Adult</AgeBand>
+    <EffectiveDate>2023-01-01</EffectiveDate>
+    <ExpirationDate>2023-12-31</ExpirationDate>
+    <Factor>1.05</Factor>
+  </Rate>
+</SimpleExposureRates>

--- a/serdiff/__init__.py
+++ b/serdiff/__init__.py
@@ -1,0 +1,6 @@
+"""SER Snapshot Diff Automation package."""
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/serdiff/cli.py
+++ b/serdiff/cli.py
@@ -1,0 +1,188 @@
+"""Command line interface for the ser-diff tool."""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+from . import __version__
+from .diff import DiffConfig, diff_files, write_reports
+from .presets import get_preset
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+EXIT_GATES_FAILED = 2
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="ser-diff",
+        description="Diff BEFORE and AFTER PolicyCenter exports for SER and Exposure Types tables.",
+    )
+    parser.add_argument("--before", required=True, help="Path to the BEFORE XML export")
+    parser.add_argument("--after", required=True, help="Path to the AFTER XML export")
+
+    table_group = parser.add_mutually_exclusive_group(required=False)
+    table_group.add_argument("--table", choices=["SER", "EXPOSURE", "custom"], help="Preset table to use")
+    table_group.add_argument("--record-path", help="XPath to the repeating record elements")
+
+    parser.add_argument(
+        "--key",
+        action="append",
+        dest="keys",
+        help="Field to use as part of the composite key (repeatable)",
+    )
+    parser.add_argument(
+        "--fields",
+        help="Comma separated list of fields to compare (overrides preset)",
+    )
+    parser.add_argument("--out-prefix", default="diff_report", help="Output prefix for generated reports")
+    parser.add_argument("--jira", help="Jira ID to embed in report metadata and filenames")
+    parser.add_argument(
+        "--expected-partners",
+        help="Comma separated list of expected partners; others will raise alerts",
+    )
+    parser.add_argument("--max-added", type=int, help="Maximum allowed added records before failing")
+    parser.add_argument("--max-removed", type=int, help="Maximum allowed removed records before failing")
+    parser.add_argument(
+        "--fail-on-unexpected",
+        action="store_true",
+        help="Exit with status 2 if unexpected partners or thresholds are exceeded",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "csv", "all"],
+        default="all",
+        help="Report format to generate",
+    )
+    parser.add_argument(
+        "--excel",
+        help="Optional Excel workbook for future validation (stub)",
+    )
+    parser.add_argument("--version", action="version", version=f"ser-diff {__version__}")
+
+    return parser.parse_args(argv)
+
+
+def _resolve_config(args: argparse.Namespace) -> DiffConfig:
+    table_name: str | None = getattr(args, "table", None)
+
+    if args.table and args.table != "custom":
+        preset = get_preset(args.table)
+        config = preset.config
+        fields = list(config.fields)
+        record_path = config.record_path
+        key_fields = list(config.key_fields)
+        table_name = config.table_name
+    else:
+        if not args.record_path:
+            raise SystemExit("--record-path is required when --table is not provided")
+        if not args.keys:
+            raise SystemExit("At least one --key must be provided for custom tables")
+        record_path = args.record_path
+        key_fields = [list(args.keys)]
+        fields = list(args.keys)
+
+    if args.fields:
+        fields = tuple(field.strip() for field in args.fields.split(",") if field.strip())
+        if not fields:
+            raise SystemExit("--fields must contain at least one field name")
+    else:
+        fields = tuple(fields)
+
+    key_field_set = {field for key_group in key_fields for field in key_group}
+    for key_field in key_field_set:
+        if key_field not in fields:
+            fields = tuple(list(fields) + [key_field])
+
+    return DiffConfig(
+        record_path=record_path,
+        fields=fields,
+        key_fields=[tuple(group) for group in key_fields],
+        table_name=table_name,
+    )
+
+
+def _parse_expected_partners(value: str | None) -> list[str] | None:
+    if not value:
+        return None
+    partners = [partner.strip() for partner in value.split(",") if partner.strip()]
+    return partners or None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    config = _resolve_config(args)
+    expected_partners = _parse_expected_partners(args.expected_partners)
+
+    before_path = Path(args.before)
+    after_path = Path(args.after)
+
+    out_prefix = (
+        Path(f"{args.out_prefix}_{args.jira}") if args.jira else Path(args.out_prefix)
+    )
+
+    if args.excel:
+        print("Excel validation is not implemented yet (TODO)", file=sys.stderr)
+
+    try:
+        result = diff_files(
+            before_path,
+            after_path,
+            config,
+            jira=args.jira,
+            expected_partners=expected_partners,
+        )
+    except Exception as exc:  # pragma: no cover - CLI guardrail
+        print(f"Error: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+
+    write_reports(result, out_prefix, output_format=args.format)
+
+    exit_code = EXIT_SUCCESS
+    failures: list[str] = []
+
+    if expected_partners and result.unexpected_partners:
+        failures.append(
+            "Unexpected partners detected: " + ", ".join(result.unexpected_partners)
+        )
+
+    added = result.summary.get("added", 0)
+    removed = result.summary.get("removed", 0)
+
+    if args.max_added is not None and added > args.max_added:
+        failures.append(f"Added records {added} exceed threshold {args.max_added}")
+    if args.max_removed is not None and removed > args.max_removed:
+        failures.append(f"Removed records {removed} exceed threshold {args.max_removed}")
+
+    if failures:
+        message = "; ".join(failures)
+        print(f"\nGATES FAILED: {message}", file=sys.stderr)
+        exit_code = EXIT_GATES_FAILED if args.fail_on_unexpected else EXIT_FAILURE
+
+    _print_summary(result)
+    _print_outputs(result.output_files)
+
+    return exit_code
+
+
+def _print_summary(result) -> None:
+    print("\nDiff Summary")
+    print("-------------")
+    for key in ["added", "removed", "updated", "total_before", "total_after", "total_changed"]:
+        if key in result.summary:
+            print(f"{key.replace('_', ' ').title()}: {result.summary[key]}")
+    if result.unexpected_partners:
+        print("Unexpected partners: " + ", ".join(result.unexpected_partners))
+
+
+def _print_outputs(paths: Iterable[str]) -> None:
+    print("\nGenerated reports:")
+    for path in paths:
+        print(f"  - {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/serdiff/diff.py
+++ b/serdiff/diff.py
@@ -1,0 +1,333 @@
+"""Core diff logic for SER Snapshot Diff Automation."""
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _strip_namespace(tag: str) -> str:
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _normalise_text(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.strip().split())
+
+
+@dataclass
+class DiffConfig:
+    record_path: str
+    fields: Sequence[str]
+    key_fields: Sequence[Sequence[str]]
+    table_name: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.fields:
+            raise ValueError("fields must not be empty")
+        if not self.key_fields:
+            raise ValueError("key_fields must not be empty")
+
+
+@dataclass
+class DiffResult:
+    summary: dict[str, int]
+    meta: dict[str, object]
+    added: list[dict[str, object]]
+    removed: list[dict[str, object]]
+    updated: list[dict[str, object]]
+    unexpected_partners: list[str] = field(default_factory=list)
+    output_files: list[str] = field(default_factory=list)
+
+
+class DuplicateKeyError(RuntimeError):
+    """Raised when duplicate keys are encountered within the same dataset."""
+
+
+def _iter_records(
+    xml_path: Path,
+    record_path: str,
+    fields: Sequence[str],
+    key_sets: Sequence[Sequence[str]],
+) -> Iterator[tuple[str, Sequence[str], dict[str, str]]]:
+    """Yield records extracted from the XML file.
+
+    Yields tuples of (key_string, key_fields_used, record_dict).
+    """
+
+    if record_path.endswith("//"):
+        raise ValueError("record_path must not end with //")
+
+    path_parts = [part for part in record_path.split("/") if part and part != "."]
+    if not path_parts:
+        raise ValueError(f"Invalid record_path: {record_path}")
+
+    target_tag = path_parts[-1]
+
+    def matches_path(elem: ET.Element) -> bool:
+        return _strip_namespace(elem.tag) == target_tag
+
+    context = ET.iterparse(str(xml_path), events=("end",))
+    for _event, elem in context:
+        if not matches_path(elem):
+            continue
+
+        record: dict[str, str] = {}
+        for field_name in fields:
+            record[field_name] = _normalise_text(_find_child_text(elem, field_name))
+
+        key_string, key_fields_used = _derive_key(record, key_sets)
+        yield key_string, key_fields_used, record
+        elem.clear()
+
+
+def _find_child_text(elem: ET.Element, child_name: str) -> str | None:
+    target = child_name.lower()
+    for child in elem:
+        if _strip_namespace(child.tag).lower() == target:
+            return child.text
+    return None
+
+
+def _derive_key(record: dict[str, str], key_sets: Sequence[Sequence[str]]) -> tuple[str, Sequence[str]]:
+    for key_fields in key_sets:
+        values = [record.get(field, "") for field in key_fields]
+        if any(value for value in values):
+            key_string = "|".join(
+                f"{field}={value}" for field, value in zip(key_fields, values, strict=True)
+            )
+            return key_string, key_fields
+    raise ValueError("Unable to derive key for record; all key fields are empty")
+
+
+def _compute_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _collect_partners(records: Iterable[dict[str, str]]) -> list[str]:
+    partners: list[str] = []
+    for record in records:
+        partner = record.get("Partner", "")
+        if partner:
+            partners.append(partner)
+    return partners
+
+
+def diff_files(
+    before: Path,
+    after: Path,
+    config: DiffConfig,
+    *,
+    jira: str | None = None,
+    expected_partners: Sequence[str] | None = None,
+) -> DiffResult:
+    before_records: dict[str, dict[str, str]] = {}
+    before_keys_used: dict[str, Sequence[str]] = {}
+    for key, key_fields_used, record in _iter_records(before, config.record_path, config.fields, config.key_fields):
+        if key in before_records:
+            raise DuplicateKeyError(f"Duplicate key {key!r} found in BEFORE file {before}")
+        before_records[key] = record
+        before_keys_used[key] = key_fields_used
+
+    after_records: dict[str, dict[str, str]] = {}
+    after_keys_used: dict[str, Sequence[str]] = {}
+    for key, key_fields_used, record in _iter_records(after, config.record_path, config.fields, config.key_fields):
+        if key in after_records:
+            raise DuplicateKeyError(f"Duplicate key {key!r} found in AFTER file {after}")
+        after_records[key] = record
+        after_keys_used[key] = key_fields_used
+
+    added: list[dict[str, object]] = []
+    removed: list[dict[str, object]] = []
+    updated: list[dict[str, object]] = []
+
+    for key, after_record in sorted(after_records.items()):
+        if key not in before_records:
+            added.append(
+                {
+                    "key": key,
+                    "key_fields": list(after_keys_used[key]),
+                    "before": {},
+                    "after": after_record,
+                }
+            )
+
+    for key, before_record in sorted(before_records.items()):
+        if key not in after_records:
+            removed.append(
+                {
+                    "key": key,
+                    "key_fields": list(before_keys_used[key]),
+                    "before": before_record,
+                    "after": {},
+                }
+            )
+
+    for key in sorted(set(before_records) & set(after_records)):
+        before_record = before_records[key]
+        after_record = after_records[key]
+        changes = {}
+        for field_name in config.fields:
+            before_value = before_record.get(field_name, "")
+            after_value = after_record.get(field_name, "")
+            if before_value != after_value:
+                changes[field_name] = {"before": before_value, "after": after_value}
+        if changes:
+            updated.append(
+                {
+                    "key": key,
+                    "key_fields": list(before_keys_used.get(key, ())),
+                    "changes": changes,
+                    "before": before_record,
+                    "after": after_record,
+                }
+            )
+
+    partner_pool = _collect_partners(after_records.values()) + _collect_partners(before_records.values())
+    unique_partners = sorted(set(partner_pool))
+    unexpected_partners: list[str] = []
+    if expected_partners:
+        expected_set = {partner.strip() for partner in expected_partners if partner.strip()}
+        unexpected_partners = sorted({partner for partner in unique_partners if partner not in expected_set})
+
+    summary = {
+        "added": len(added),
+        "removed": len(removed),
+        "updated": len(updated),
+        "total_before": len(before_records),
+        "total_after": len(after_records),
+        "total_changed": len(added) + len(removed) + len(updated),
+    }
+
+    meta = {
+        "jira": jira,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "table": config.table_name,
+        "before_file": {
+            "path": str(before),
+            "sha256": _compute_hash(before),
+        },
+        "after_file": {
+            "path": str(after),
+            "sha256": _compute_hash(after),
+        },
+        "record_path": config.record_path,
+        "fields": list(config.fields),
+        "key_fields": [list(keys) for keys in config.key_fields],
+        "partners_detected": unique_partners,
+        "expected_partners": list(expected_partners) if expected_partners else [],
+    }
+
+    return DiffResult(
+        summary=summary,
+        meta=meta,
+        added=added,
+        removed=removed,
+        updated=updated,
+        unexpected_partners=unexpected_partners,
+    )
+
+
+def write_reports(result: DiffResult, out_prefix: Path, *, output_format: str = "all") -> list[str]:
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+    produced: list[str] = []
+
+    if output_format in {"all", "json"}:
+        json_path = out_prefix.with_suffix(".json")
+        payload = {
+            "summary": result.summary,
+            "meta": result.meta,
+            "added": result.added,
+            "removed": result.removed,
+            "updated": result.updated,
+            "unexpected_partners": result.unexpected_partners,
+        }
+        with json_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        produced.append(str(json_path))
+
+    if output_format in {"all", "csv"}:
+        produced.extend(_write_csv_reports(result, out_prefix))
+
+    result.output_files = produced
+    return produced
+
+
+def _write_csv_reports(result: DiffResult, out_prefix: Path) -> list[str]:
+    produced: list[str] = []
+
+    summary_path = Path(f"{out_prefix}_summary.csv")
+    with summary_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["metric", "value"])
+        for metric, value in result.summary.items():
+            writer.writerow([metric, value])
+        writer.writerow(["unexpected_partners", ";".join(result.unexpected_partners)])
+    produced.append(str(summary_path))
+
+    added_path = Path(f"{out_prefix}_added.csv")
+    _write_record_csv(added_path, result.added)
+    produced.append(str(added_path))
+
+    removed_path = Path(f"{out_prefix}_removed.csv")
+    _write_record_csv(removed_path, result.removed)
+    produced.append(str(removed_path))
+
+    updated_path = Path(f"{out_prefix}_updated.csv")
+    with updated_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["key", "field", "before", "after"])
+        for record in result.updated:
+            key = record.get("key", "")
+            changes = record.get("changes", {})
+            for field, change in changes.items():
+                writer.writerow([key, field, change.get("before", ""), change.get("after", "")])
+    produced.append(str(updated_path))
+
+    return produced
+
+
+def _write_record_csv(path: Path, records: Sequence[dict[str, object]]) -> None:
+    base_headers = sorted({
+        *(key for record in records for key in record),
+        "key",
+    })
+    headers = [header for header in base_headers if header not in {"before", "after", "changes"}]
+    headers += ["before", "after"]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(headers)
+        for record in records:
+            row = []
+            for header in headers:
+                if header == "before" or header == "after":
+                    value = record.get(header, {})
+                    row.append(json.dumps(value, ensure_ascii=False, sort_keys=True))
+                else:
+                    value = record.get(header, "")
+                    if isinstance(value, list | dict):
+                        row.append(json.dumps(value, ensure_ascii=False, sort_keys=True))
+                    else:
+                        row.append(value)
+            writer.writerow(row)
+
+
+__all__ = [
+    "DiffConfig",
+    "DiffResult",
+    "DuplicateKeyError",
+    "diff_files",
+    "write_reports",
+]

--- a/serdiff/presets.py
+++ b/serdiff/presets.py
@@ -1,0 +1,78 @@
+"""Presets for SER and Exposure Type tables."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .diff import DiffConfig
+
+
+@dataclass(frozen=True)
+class Preset:
+    name: str
+    config: DiffConfig
+    description: str
+
+
+def _build_presets() -> dict[str, Preset]:
+    presets: dict[str, Preset] = {}
+
+    ser_config = DiffConfig(
+        record_path=".//Rate",
+        fields=[
+            "PublicID",
+            "Partner",
+            "State",
+            "AgeBand",
+            "EffectiveDate",
+            "ExpirationDate",
+            "Factor",
+        ],
+        key_fields=[
+            ["PublicID"],
+            ["Partner", "State", "AgeBand", "EffectiveDate"],
+        ],
+        table_name="SER",
+    )
+    presets["SER"] = Preset(
+        name="SER",
+        config=ser_config,
+        description="Simple Exposure Rates table preset",
+    )
+
+    exposure_config = DiffConfig(
+        record_path=".//ExposureType",
+        fields=[
+            "PublicID",
+            "ExposureCode",
+            "Partner",
+            "State",
+            "EffectiveDate",
+            "ExpirationDate",
+        ],
+        key_fields=[["PublicID"]],
+        table_name="EXPOSURE",
+    )
+    presets["EXPOSURE"] = Preset(
+        name="EXPOSURE",
+        config=exposure_config,
+        description="Exposure Types table preset",
+    )
+
+    return presets
+
+
+PRESETS: dict[str, Preset] = _build_presets()
+
+
+def list_presets() -> list[Preset]:
+    return list(PRESETS.values())
+
+
+def get_preset(name: str) -> Preset:
+    try:
+        return PRESETS[name.upper()]
+    except KeyError as exc:
+        raise KeyError(f"Unknown preset {name!r}") from exc
+
+
+__all__ = ["Preset", "PRESETS", "get_preset", "list_presets"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from serdiff import cli
+from serdiff.diff import diff_files
+from serdiff.presets import get_preset
+
+
+def write_xml(path: Path, body: str) -> Path:
+    path.write_text(body.strip(), encoding="utf-8")
+    return path
+
+
+def test_cli_threshold_failure(tmp_path: Path) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+          <Rate>
+            <PublicID>SER-NEW-01</PublicID>
+            <Partner>Uber</Partner>
+            <State>CA</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-05-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.30</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+
+    exit_code = cli.main(
+        [
+            "--before",
+            str(before),
+            "--after",
+            str(after),
+            "--table",
+            "SER",
+            "--max-added",
+            "0",
+            "--fail-on-unexpected",
+        ]
+    )
+
+    assert exit_code == cli.EXIT_GATES_FAILED
+
+
+def test_expected_partner_detection(tmp_path: Path) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+          <Rate>
+            <PublicID>SER-DOORDASH-01</PublicID>
+            <Partner>DoorDash</Partner>
+            <State>TX</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.00</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+
+    preset = get_preset("SER")
+    result = diff_files(
+        Path(before),
+        Path(after),
+        preset.config,
+        jira="TEST-1",
+        expected_partners=["Uber"],
+    )
+    assert "DoorDash" in result.unexpected_partners

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from serdiff.diff import DiffConfig, diff_files
+from serdiff.presets import get_preset
+
+
+@pytest.fixture
+def ser_config() -> DiffConfig:
+    return get_preset("SER").config
+
+
+def write_xml(path: Path, body: str) -> Path:
+    path.write_text(body.strip(), encoding="utf-8")
+    return path
+
+
+def test_ser_diff_add_remove_update(tmp_path: Path, ser_config: DiffConfig) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+          <Rate>
+            <PublicID>SER-HELLO-CA</PublicID>
+            <Partner>HelloFresh</Partner>
+            <State>CA</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>0.95</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.20</Factor>
+          </Rate>
+          <Rate>
+            <PublicID>SER-MARSH-IL</PublicID>
+            <Partner>Marsh Risk</Partner>
+            <State>IL</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-06-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.40</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+
+    result = diff_files(before, after, ser_config)
+
+    assert result.summary["added"] == 1
+    assert result.summary["removed"] == 1
+    assert result.summary["updated"] == 1
+    updated = result.updated[0]
+    assert updated["key"] == "PublicID=SER-UBER-NY"
+    assert updated["changes"]["Factor"] == {"before": "1.10", "after": "1.20"}
+
+
+def test_composite_key_support(tmp_path: Path, ser_config: DiffConfig) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <Partner>Uber</Partner>
+            <State>WA</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.00</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <Partner>Uber</Partner>
+            <State>WA</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.05</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+
+    result = diff_files(before, after, ser_config)
+    assert result.summary["updated"] == 1
+    assert result.updated[0]["key"].startswith("Partner=Uber")
+
+
+def test_whitespace_normalisation(tmp_path: Path, ser_config: DiffConfig) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner> Uber </Partner>
+            <State> NY </State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate> 2023-01-01 </EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <SimpleExposureRates>
+          <Rate>
+            <PublicID>SER-UBER-NY</PublicID>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <AgeBand>Adult</AgeBand>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+            <Factor>1.10</Factor>
+          </Rate>
+        </SimpleExposureRates>
+        """,
+    )
+
+    result = diff_files(before, after, ser_config)
+    assert result.summary["updated"] == 0


### PR DESCRIPTION
## Summary
- implement streaming XML diff core that produces JSON/CSV artifacts with metadata and gating hooks
- add argparse-powered ser-diff CLI with presets, partner/threshold enforcement, and report generation
- document usage, ship samples, demo reports, Makefile, and CI for lint/tests/demo artifacts

## Testing
- `python -m ruff check serdiff tests`
- `pytest`
- `python -m serdiff.cli --before samples/SER_before.xml --after samples/SER_after.xml --table SER --out-prefix reports/sample_SER --jira SAMPLE-SER`
- `python -m serdiff.cli --before samples/EXPOSURE_before.xml --after samples/EXPOSURE_after.xml --table EXPOSURE --out-prefix reports/sample_EXPOSURE --jira SAMPLE-EXP`


------
https://chatgpt.com/codex/tasks/task_e_68e403831240832f9de8d61e811e1025