### PR TITLE
fix(html-report): safely embed JSON payload in <script type="application/json">

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags:
+      - "v*"
   pull_request:
     branches: [ main ]
 
@@ -57,3 +59,53 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
           compression-level: 6
+
+  release-binaries:
+    name: Release single-file binaries
+    needs: build-test
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            extension: ""
+            asset_name: ser-diff-linux
+          - os: macos-latest
+            extension: ""
+            asset_name: ser-diff-macos
+          - os: windows-latest
+            extension: ".exe"
+            asset_name: ser-diff-windows.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller .
+
+      - name: Build single-file binary
+        run: |
+          pyinstaller --name ser-diff --onefile --console -p src -m serdiff.cli
+        shell: bash
+
+      - name: Rename artifact
+        run: |
+          mkdir -p dist
+          mv dist/ser-diff${{ matrix.extension }} dist/${{ matrix.asset_name }}
+        shell: bash
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/${{ matrix.asset_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e .[dev]
+
+      - name: Lint and test
+        run: make lint test
+
+      - name: Generate demo reports
+        run: |
+          mkdir -p reports
+          ser-diff --before samples/SER_before.xml --after samples/SER_after.xml \
+            --table SER --report html --out-prefix reports/demo-ser
+          ser-diff --before samples/EXPOSURE_before.xml --after samples/EXPOSURE_after.xml \
+            --table EXPOSURE --report xlsx --out-prefix reports/demo-exposure
+
+      - name: Upload reports artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ser-diff-demo-artifacts
+          path: reports
+          if-no-files-found: error
+
+  release-binaries:
+    name: Build single-file binaries
+    needs: build-artifacts
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: ser-diff-linux
+            extension: ""
+          - os: macos-latest
+            asset: ser-diff-macos
+            extension: ""
+          - os: windows-latest
+            asset: ser-diff-windows.exe
+            extension: ".exe"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller .
+
+      - name: Build binary
+        run: pyinstaller --name ser-diff --onefile --console -p src -m serdiff.cli
+
+      - name: Prepare asset
+        env:
+          TARGET_NAME: ${{ matrix.asset }}
+          SOURCE_EXT: ${{ matrix.extension }}
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import shutil
+
+          dist = pathlib.Path("dist")
+          dist.mkdir(exist_ok=True)
+          source = dist / f"ser-diff{os.environ['SOURCE_EXT']}"
+          target = dist / os.environ["TARGET_NAME"]
+          if not source.exists():
+              raise SystemExit(f"expected binary at {source} before renaming")
+          if target.exists():
+              target.unlink()
+          shutil.move(source, target)
+          PY
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/${{ matrix.asset }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,16 @@ __pycache__/
 dist/
 build/
 *.egg-info/
+
+# block binary assets from being committed
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.xlsx
+*.xlsm
+*.pdf
+
+tests/_generated/
 reports/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/johnsoncodehk/deny-binaries
+    rev: v1.2.0
+    hooks:
+      - id: deny-binaries
+        args: ["--maxkb=256"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- `ser-diff doctor` command that validates Python, OS, XML parser support, and report directory permissions.
+- pipx-first installation guidance and installation doctor documentation.
+- Release automation to build and upload single-file binaries on tagged releases.
+- `docs/install.md` with PyInstaller build steps for macOS, Linux, and Windows.
+- Repo-local configuration loader with `.serdiff.toml` precedence (TOML > YAML > JSON) and a `ser-diff init` generator.
+- CLI now honours config defaults while keeping CLI flags authoritative and supports `--no-fail-on-unexpected`/`--no-strip-ns` overrides.
+- Canonical `diff.json` (schema v1.0) emitted for every run including threshold metadata for CI automation.
+- Single-file HTML reporting via `--report html` with inline assets and an embedded canonical JSON payload.
+- Single-file XLSX reporting via `--report xlsx` that mirrors the HTML report with Summary/Added/Removed/Changed worksheets.
+- `ser-diff explain` subcommand (with `--json`) for reusable diagnostics plus richer console summaries during `ser-diff` runs.
+- Guardrail handling now exits with status `2` when `--fail-on-unexpected` or `--strict` flags are set while still producing all report artifacts.
+- Example CI release workflow (`.github/workflows/release.yml`) and README guidance covering artifact uploads and tagged binary builds.
+
+### Fixed
+- Safely escape embedded JSON in the HTML report to prevent premature `</script>` termination and retain Unicode line separators.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 include README.md
+include CHANGELOG.md
 include LICENSE
 exclude reports/*
 exclude samples/*
+recursive-include docs *.md
+prune docs/assets

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ venv:
 	$(VENV)/bin/pip install -e .[dev]
 
 fmt:
-	$(PYTHON) -m black src/serdiff tests
-	$(PYTHON) -m ruff check src/serdiff tests --fix
+	black .
+	ruff check --fix .
 
 lint:
-	$(PYTHON) -m ruff check src/serdiff tests
+	ruff check .
+	black --check .
 
 test:
-	$(PYTHON) -m pytest
+	pytest -q
 
 demo:
 	ser-diff --before samples/SER_before.xml --after samples/SER_after.xml --table SER --out-prefix reports/demo_SER --jira DEMO-SER

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,40 @@
+# Installation and Single-File Binaries
+
+`ser-diff` is published as a standard Python package. The recommended way to install it is with [`pipx`](https://pipx.pypa.io/):
+
+```bash
+pipx install ser-diff
+```
+
+When developing locally, you can also install from a checkout:
+
+```bash
+pipx install .
+```
+
+## Building Single-File Binaries
+
+For environments that do not have Python available, you can produce self-contained executables using [PyInstaller](https://pyinstaller.org/en/stable/). The commands below assume you are running them from the project root.
+
+### macOS and Linux
+
+```bash
+pipx run pyinstaller --name ser-diff --onefile --console -p src -m serdiff.cli
+mkdir -p dist
+mv dist/ser-diff dist/ser-diff-$(uname -s | tr '[:upper:]' '[:lower:]')
+```
+
+The resulting binary is placed in `dist/ser-diff-linux` on Linux and `dist/ser-diff-darwin` on macOS. Copy it to your desired distribution channel.
+
+### Windows (PowerShell)
+
+```powershell
+pipx run pyinstaller --name ser-diff --onefile --console -p src -m serdiff.cli
+Rename-Item dist\ser-diff.exe dist\ser-diff-windows.exe
+```
+
+After building, run the executable with `ser-diff.exe doctor` to confirm it works on the target machine.
+
+## Release Automation
+
+Tagged releases automatically build the three single-file binaries (Windows, macOS, Linux) and upload them as GitHub release assets. See `.github/workflows/ci.yml` for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,11 @@ authors = [{name = "SER Snapshot Diff Automation", email = "eng@example.com"}]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+  "PyYAML>=6.0",
+  "tomli>=2.0; python_version < '3.11'",
+  "openpyxl>=3.1",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -31,11 +35,28 @@ pythonpath = ["src"]
 
 [tool.black]
 line-length = 100
-target-version = ["py310"]
+target-version = ["py310", "py312"]
+include = "\\.pyi?$"
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | build
+  | dist
+  | \.mypy_cache
+  | \.ruff_cache
+)/
+'''
 
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+fix = true
+exclude = [
+  ".venv",
+  "build",
+  "dist",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "C4", "SIM", "N"]

--- a/src/serdiff/cli.py
+++ b/src/serdiff/cli.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import platform
 import sys
 from collections.abc import Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
 from . import __version__
+from .config import LoadedConfig, load_config
 from .detect import ROW_INDEX_FIELD, detect_schema, infer_fields, infer_key_fields, probe_xml
-from .diff import DiffConfig, diff_files, write_reports
+from .diff import DiffConfig, DiffResult, diff_files, write_reports
 from .presets import get_preset
 
 EXIT_SUCCESS = 0
@@ -26,11 +31,14 @@ class RunSetup:
     warnings: list[str]
 
 
-def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        prog="ser-diff",
-        description="Diff BEFORE and AFTER PolicyCenter exports for SER and Exposure Types tables.",
-    )
+def _create_diff_parser(
+    *,
+    prog: str,
+    description: str,
+    include_explain_flag: bool = True,
+    include_json_flag: bool = False,
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument("--before", required=True, help="Path to the BEFORE XML export")
     parser.add_argument("--after", required=True, help="Path to the AFTER XML export")
 
@@ -46,7 +54,8 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--strip-ns",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Strip XML namespaces during parsing (useful for default namespaces)",
     )
 
@@ -56,11 +65,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Automatically detect schema, keys, and fields (default when no table provided)",
     )
-    parser.add_argument(
-        "--explain",
-        action="store_true",
-        help="Print detected schema, key, and field information",
-    )
+    if include_explain_flag:
+        parser.add_argument(
+            "--explain",
+            action="store_true",
+            help="Print detected schema, key, and field information",
+        )
     parser.add_argument(
         "--strict",
         action="store_true",
@@ -78,12 +88,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Comma separated list of fields to compare (overrides preset)",
     )
     parser.add_argument(
-        "--out-prefix", default="diff_report", help="Output prefix for generated reports"
+        "--out-prefix",
+        default=None,
+        help="Output prefix for generated reports (default: diff_report)",
     )
     parser.add_argument(
         "--output-dir",
-        default="reports",
-        help="Directory to store generated reports (created if missing)",
+        default=None,
+        help="Directory to store generated reports (default: ./reports)",
     )
     parser.add_argument("--jira", help="Jira ID to embed in report metadata and filenames")
     parser.add_argument(
@@ -98,7 +110,8 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--fail-on-unexpected",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Exit with status 2 if unexpected partners or thresholds are exceeded",
     )
     parser.add_argument(
@@ -108,12 +121,215 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Report format to generate",
     )
     parser.add_argument(
+        "--report",
+        choices=["html", "xlsx"],
+        default=None,
+        help="Generate a single-file human-readable report",
+    )
+    parser.add_argument(
         "--excel",
         help="Optional Excel workbook for future validation (stub)",
     )
+    if include_json_flag:
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Emit explanation details as machine-readable JSON",
+        )
     parser.add_argument("--version", action="version", version=f"ser-diff {__version__}")
+    return parser
 
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = _create_diff_parser(
+        prog="ser-diff",
+        description="Diff BEFORE and AFTER PolicyCenter exports for SER and Exposure Types tables.",
+    )
     return parser.parse_args(argv)
+
+
+def _parse_doctor_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="ser-diff doctor",
+        description="Validate the local environment for running ser-diff.",
+    )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=Path("reports"),
+        help="Directory ser-diff uses for report output (default: ./reports)",
+    )
+    return parser.parse_args(argv)
+
+
+def _parse_explain_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = _create_diff_parser(
+        prog="ser-diff explain",
+        description="Inspect detected schema, keys, and field configuration for a run.",
+        include_explain_flag=False,
+        include_json_flag=True,
+    )
+    return parser.parse_args(argv)
+
+
+def _check_reports_dir(path: Path) -> tuple[bool, str]:
+    raw = path.expanduser()
+    try:
+        target = raw.resolve()
+    except FileNotFoundError:  # pragma: no cover - resolve may fail on some platforms
+        target = (Path.cwd() / raw).resolve()
+
+    if target.exists() and not target.is_dir():
+        return False, f"{target} exists but is not a directory"
+
+    check_path = target if target.exists() else target.parent
+    if not str(check_path):
+        check_path = Path.cwd()
+
+    existing_parent = check_path
+    while not existing_parent.exists() and existing_parent != existing_parent.parent:
+        existing_parent = existing_parent.parent
+
+    writable = os.access(existing_parent, os.W_OK | os.X_OK)
+
+    if target.exists():
+        description = f"{target} (writable)" if writable else f"{target} (not writable)"
+        return writable, description
+
+    description = f"{target} (will be created)"
+    if not writable:
+        description = f"{target} (cannot create directory)"
+    return writable, description
+
+
+def _check_xml_parser() -> tuple[bool, str]:
+    try:
+        from xml.etree.ElementTree import iterparse
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return False, f"xml.etree.ElementTree import failed: {exc}"
+
+    if not callable(iterparse):
+        return False, "xml.etree.ElementTree.iterparse unavailable"
+    return True, "xml.etree.ElementTree.iterparse available"
+
+
+def _run_doctor(argv: Sequence[str] | None = None) -> int:
+    args = _parse_doctor_args(argv)
+    checks: list[tuple[str, bool, str]] = []
+
+    checks.append(("ser-diff version", True, __version__))
+    checks.append(("Python version", True, platform.python_version()))
+    checks.append(("Operating system", True, platform.platform()))
+
+    reports_ok, reports_detail = _check_reports_dir(args.reports_dir)
+    checks.append(("Reports directory", reports_ok, reports_detail))
+
+    xml_ok, xml_detail = _check_xml_parser()
+    checks.append(("XML parser", xml_ok, xml_detail))
+
+    all_ok = all(status for _, status, _ in checks)
+
+    for label, passed, detail in checks:
+        status = "OK" if passed else "FAIL"
+        print(f"[{status}] {label}: {detail}")
+
+    if all_ok:
+        print("\nDoctor summary: All systems go.")
+        return EXIT_SUCCESS
+
+    print("\nDoctor summary: Issues detected. Please address the failed checks above.")
+    return EXIT_FAILURE
+
+
+def _run_explain(argv: Sequence[str] | None = None) -> int:
+    loaded_config = load_config(Path.cwd())
+    args = _parse_explain_args(argv)
+    args = _merge_cli_with_config(args, loaded_config)
+
+    setup = _resolve_run_setup(args)
+    config = setup.config
+    expected_partners = _parse_expected_partners(args.expected_partners)
+
+    before_path = Path(args.before)
+    after_path = Path(args.after)
+
+    try:
+        result = diff_files(
+            before_path,
+            after_path,
+            config,
+            jira=args.jira,
+            expected_partners=expected_partners,
+            strip_namespaces=bool(args.strip_ns),
+        )
+    except Exception as exc:  # pragma: no cover - CLI guardrail
+        print(f"Error: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+
+    payload = _build_explain_payload(setup, result)
+
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_explain(payload)
+
+    return EXIT_SUCCESS
+
+
+def _parse_init_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="ser-diff init",
+        description="Create a .serdiff.toml configuration template in the current directory.",
+    )
+    return parser.parse_args(argv)
+
+
+def _generate_config_template(base_dir: Path) -> str:
+    reports_dir = (base_dir / "reports").resolve()
+    reports_dir_display = str(reports_dir)
+
+    lines = [
+        "# ser-diff configuration template",
+        "# Generated by `ser-diff init`. Uncomment and edit values to customise defaults.",
+        "",
+        "[jira]",
+        '# ticket = "ENG-123"',
+        "",
+        "[io]",
+        f'# output_dir = "{reports_dir_display}"',
+        '# out_prefix = "diff_report"',
+        "",
+        "[guards]",
+        '# expected_partners = ["Partner One", "Partner Two"]',
+        "# max_added = 0",
+        "# max_removed = 0",
+        "# fail_on_unexpected = true",
+        "",
+        "[preset]",
+        '# mode = "auto"  # options: auto | SER | custom',
+        "",
+        "[custom]",
+        '# record_path = ".//Record"',
+        '# record_localname = "Record"',
+        '# keys = ["KeyField1", "KeyField2"]',
+        '# fields = ["Field1", "Field2"]',
+        "# strip_ns = false",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _run_init(argv: Sequence[str] | None = None) -> int:
+    _parse_init_args(argv)
+    target = Path.cwd() / ".serdiff.toml"
+    if target.exists():
+        print(f"Configuration already exists at {target}")
+        return EXIT_SUCCESS
+
+    template = _generate_config_template(Path.cwd())
+    target.write_text(template + "\n", encoding="utf-8")
+    print(f"Wrote configuration template to {target}")
+    return EXIT_SUCCESS
 
 
 def _ensure_fields_include_keys(
@@ -309,8 +525,203 @@ def _parse_expected_partners(value: str | None) -> list[str] | None:
     return partners or None
 
 
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        if normalised in {"true", "1", "yes", "y"}:
+            return True
+        if normalised in {"false", "0", "no", "n"}:
+            return False
+    return bool(value)
+
+
+def _build_explain_payload(setup: RunSetup, result: DiffResult) -> dict[str, object]:
+    meta = result.meta
+    summary = result.summary
+
+    key_candidates = setup.explain.get("key_candidates") or []
+    formatted_candidates: list[list[str]] = []
+    for candidate in key_candidates:
+        if isinstance(candidate, list | tuple):
+            formatted_candidates.append([str(field) for field in candidate])
+
+    payload: dict[str, object] = {
+        "mode": "auto" if setup.auto_mode else setup.explain.get("mode", "manual"),
+        "auto_mode": setup.auto_mode,
+        "schema": meta.get("schema", setup.explain.get("schema_detected", "UNKNOWN")),
+        "table": meta.get("table"),
+        "record_path": meta.get("record_path"),
+        "record_localname": meta.get("record_localname"),
+        "fields": list(meta.get("fields_used", []) or setup.explain.get("fields", [])),
+        "key_fields": list(meta.get("key_fields_used", [])),
+        "key_candidates": formatted_candidates,
+        "namespaces_detected": bool(meta.get("namespace_detected")),
+        "duplicate_handling": meta.get("duplicates_resolved", {}),
+        "warnings": list(setup.warnings),
+        "summary": {
+            "total_before": summary.get("total_before", 0),
+            "total_after": summary.get("total_after", 0),
+        },
+        "partners_detected": list(meta.get("partners_detected", [])),
+        "expected_partners": list(meta.get("expected_partners", [])),
+    }
+
+    if setup.explain.get("schema_mismatch"):
+        payload["schema_mismatch"] = setup.explain["schema_mismatch"]
+
+    if setup.config:
+        payload["configured_record_path"] = setup.config.record_path
+        payload["configured_key_fields"] = list(setup.config.key_fields)
+
+    return payload
+
+
+def _merge_cli_with_config(args: argparse.Namespace, loaded: LoadedConfig) -> argparse.Namespace:
+    config = loaded.data
+
+    if config:
+        jira_config = config.get("jira", {})
+        if args.jira is None and isinstance(jira_config, dict):
+            ticket = jira_config.get("ticket")
+            if isinstance(ticket, str) and ticket.strip():
+                args.jira = ticket.strip()
+
+        io_config = config.get("io", {})
+        if isinstance(io_config, dict):
+            output_dir = io_config.get("output_dir")
+            if args.output_dir is None and isinstance(output_dir, str) and output_dir.strip():
+                args.output_dir = output_dir.strip()
+            out_prefix = io_config.get("out_prefix")
+            if args.out_prefix is None and isinstance(out_prefix, str) and out_prefix.strip():
+                args.out_prefix = out_prefix.strip()
+
+        guards_config = config.get("guards", {})
+        if isinstance(guards_config, dict):
+            expected = guards_config.get("expected_partners")
+            if args.expected_partners is None and expected is not None:
+                if isinstance(expected, list):
+                    partners = [
+                        str(partner).strip() for partner in expected if str(partner).strip()
+                    ]
+                    if partners:
+                        args.expected_partners = ", ".join(partners)
+                elif isinstance(expected, str) and expected.strip():
+                    args.expected_partners = expected.strip()
+
+            if args.max_added is None and guards_config.get("max_added") is not None:
+                with suppress(TypeError, ValueError):
+                    args.max_added = int(guards_config["max_added"])
+
+            if args.max_removed is None and guards_config.get("max_removed") is not None:
+                with suppress(TypeError, ValueError):
+                    args.max_removed = int(guards_config["max_removed"])
+
+            fail_on_unexpected = guards_config.get("fail_on_unexpected")
+            if args.fail_on_unexpected is None and fail_on_unexpected is not None:
+                args.fail_on_unexpected = _coerce_bool(fail_on_unexpected)
+
+        preset_config = config.get("preset", {})
+        custom_config = config.get("custom", {})
+        if isinstance(preset_config, dict):
+            mode_value = preset_config.get("mode")
+            if mode_value and args.table is None and args.record_path is None and args.auto is None:
+                mode = str(mode_value).strip().lower()
+                if mode == "auto":
+                    args.auto = True
+                elif mode in {"ser", "exposure"}:
+                    args.table = mode.upper()
+                elif mode == "custom" and isinstance(custom_config, dict):
+                    record_path = custom_config.get("record_path")
+                    if args.record_path is None and isinstance(record_path, str):
+                        args.record_path = record_path
+                    record_localname = custom_config.get("record_localname")
+                    if (
+                        args.record_localname is None
+                        and isinstance(record_localname, str)
+                        and record_localname.strip()
+                    ):
+                        args.record_localname = record_localname.strip()
+                    if not args.keys:
+                        keys = custom_config.get("keys")
+                        if isinstance(keys, list):
+                            args.keys = [str(key) for key in keys if str(key).strip()]
+                    if args.fields is None:
+                        fields = custom_config.get("fields")
+                        if isinstance(fields, list):
+                            field_names = [
+                                str(field).strip() for field in fields if str(field).strip()
+                            ]
+                            if field_names:
+                                args.fields = ", ".join(field_names)
+                        elif isinstance(fields, str) and fields.strip():
+                            args.fields = fields.strip()
+                    strip_ns = custom_config.get("strip_ns")
+                    if args.strip_ns is None and strip_ns is not None:
+                        args.strip_ns = _coerce_bool(strip_ns)
+                    args.auto = False
+
+    if args.output_dir is None:
+        args.output_dir = "reports"
+    if args.out_prefix is None:
+        args.out_prefix = "diff_report"
+    if args.fail_on_unexpected is None:
+        args.fail_on_unexpected = False
+    if args.strip_ns is None:
+        args.strip_ns = False
+
+    return args
+
+
+def _evaluate_thresholds(
+    result: DiffResult,
+    *,
+    expected_partners: Sequence[str] | None,
+    max_added: int | None,
+    max_removed: int | None,
+) -> tuple[dict[str, object], list[str]]:
+    summary = result.summary
+    added = summary.get("added", 0)
+    removed = summary.get("removed", 0)
+
+    violations: list[str] = []
+    messages: list[str] = []
+
+    if expected_partners and result.unexpected_partners:
+        violations.append("UNEXPECTED_PARTNER")
+        messages.append("Unexpected partners detected: " + ", ".join(result.unexpected_partners))
+
+    if max_added is not None and added > max_added:
+        violations.append("MAX_ADDED")
+        messages.append(f"Added records {added} exceed threshold {max_added}")
+
+    if max_removed is not None and removed > max_removed:
+        violations.append("MAX_REMOVED")
+        messages.append(f"Removed records {removed} exceed threshold {max_removed}")
+
+    thresholds = {
+        "max_added": max_added,
+        "max_removed": max_removed,
+        "violations": violations,
+    }
+
+    return thresholds, messages
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _parse_args(argv)
+    argv_list = list(sys.argv[1:]) if argv is None else list(argv)
+
+    if argv_list and argv_list[0] == "doctor":
+        return _run_doctor(argv_list[1:])
+    if argv_list and argv_list[0] == "init":
+        return _run_init(argv_list[1:])
+    if argv_list and argv_list[0] == "explain":
+        return _run_explain(argv_list[1:])
+
+    loaded_config = load_config(Path.cwd())
+    args = _parse_args(argv_list)
+    args = _merge_cli_with_config(args, loaded_config)
 
     setup = _resolve_run_setup(args)
     config = setup.config
@@ -338,13 +749,26 @@ def main(argv: Sequence[str] | None = None) -> int:
             config,
             jira=args.jira,
             expected_partners=expected_partners,
-            strip_namespaces=args.strip_ns,
+            strip_namespaces=bool(args.strip_ns),
         )
     except Exception as exc:  # pragma: no cover - CLI guardrail
         print(f"Error: {exc}", file=sys.stderr)
         return EXIT_FAILURE
 
-    produced_paths = write_reports(result, out_prefix, output_format=args.format)
+    thresholds, threshold_messages = _evaluate_thresholds(
+        result,
+        expected_partners=expected_partners,
+        max_added=args.max_added,
+        max_removed=args.max_removed,
+    )
+
+    produced_paths = write_reports(
+        result,
+        out_prefix,
+        output_format=args.format,
+        report_type=args.report,
+        thresholds=thresholds,
+    )
 
     strict_issues: list[str] = []
 
@@ -358,31 +782,22 @@ def main(argv: Sequence[str] | None = None) -> int:
     if setup.warnings:
         strict_issues.extend(setup.warnings)
 
-    exit_code = EXIT_SUCCESS
-    failures: list[str] = []
-
-    if expected_partners and result.unexpected_partners:
-        failures.append("Unexpected partners detected: " + ", ".join(result.unexpected_partners))
-
-    added = result.summary.get("added", 0)
-    removed = result.summary.get("removed", 0)
-
-    if args.max_added is not None and added > args.max_added:
-        failures.append(f"Added records {added} exceed threshold {args.max_added}")
-    if args.max_removed is not None and removed > args.max_removed:
-        failures.append(f"Removed records {removed} exceed threshold {args.max_removed}")
-
+    failures: list[str] = list(threshold_messages)
     if failures:
-        message = "; ".join(failures)
-        print(f"\nGATES FAILED: {message}", file=sys.stderr)
-        exit_code = EXIT_GATES_FAILED if args.fail_on_unexpected else EXIT_FAILURE
+        for failure in failures:
+            print(f"Warning: {failure}", file=sys.stderr)
 
     summary = result.summary
     summary_line = (
-        f"Diff: added={summary.get('added', 0)} removed={summary.get('removed', 0)} "
-        f"updated={summary.get('updated', 0)} "
-        f"(before={summary.get('total_before', 0)}, after={summary.get('total_after', 0)}). "
-        f"Reports at: {out_prefix}"
+        "Diff summary | added: {added} | removed: {removed} | changed: {changed} | "
+        "before: {before} | after: {after} | output: {output}"
+    ).format(
+        added=summary.get("added", 0),
+        removed=summary.get("removed", 0),
+        changed=summary.get("updated", 0),
+        before=summary.get("total_before", 0),
+        after=summary.get("total_after", 0),
+        output=str(out_prefix),
     )
     print(summary_line)
 
@@ -405,41 +820,74 @@ def main(argv: Sequence[str] | None = None) -> int:
     for path in produced_paths:
         print(f"  - {path}")
 
-    if args.explain:
-        _print_explain(setup, result)
+    guardrail_triggered = False
+
+    if failures and args.fail_on_unexpected:
+        guardrail_triggered = True
 
     if args.strict and strict_issues:
-        exit_code = max(exit_code, EXIT_GATES_FAILED)
+        guardrail_triggered = True
+        print("Strict mode guardrails triggered:", file=sys.stderr)
+        for issue in strict_issues:
+            print(f"  - {issue}", file=sys.stderr)
 
-    return exit_code
+    if args.explain:
+        explain_payload = _build_explain_payload(setup, result)
+        _print_explain(explain_payload)
+
+    return EXIT_GATES_FAILED if guardrail_triggered else EXIT_SUCCESS
 
 
-def _print_explain(setup: RunSetup, result) -> None:
-    meta = result.meta
+def _print_explain(payload: dict[str, object]) -> None:
     print("\nExplain")
     print("-------")
-    mode = "auto" if setup.auto_mode else setup.explain.get("mode", "manual")
+    mode = payload.get("mode", "manual")
     print(f"Mode: {mode}")
-    print(f"Schema: {meta.get('schema', 'UNKNOWN')}")
-    print(f"Record localname: {meta.get('record_localname') or 'n/a'}")
-    fields_used = ", ".join(meta.get("fields_used", []))
-    print(f"Fields used: {fields_used or 'n/a'}")
-    key_used = ", ".join(meta.get("key_fields_used", []))
-    print(f"Key fields: {key_used or 'n/a'}")
-    duplicates = meta.get("duplicates_resolved", {})
-    if duplicates.get("resolved"):
+    schema = payload.get("schema") or "UNKNOWN"
+    print(f"Schema: {schema}")
+    table = payload.get("table")
+    if table:
+        print(f"Table preset: {table}")
+    record_path = payload.get("record_path") or payload.get("configured_record_path")
+    if record_path:
+        print(f"Record path: {record_path}")
+    record_localname = payload.get("record_localname") or "n/a"
+    print(f"Record localname: {record_localname}")
+    summary = payload.get("summary", {})
+    if isinstance(summary, dict):
+        before_total = summary.get("total_before", 0)
+        after_total = summary.get("total_after", 0)
+        print(f"Records parsed: before={before_total}, after={after_total}")
+    fields = payload.get("fields") or []
+    fields_display = ", ".join(str(field) for field in fields) or "n/a"
+    print(f"Fields compared: {fields_display}")
+    key_fields = payload.get("key_fields") or []
+    key_display = ", ".join(str(field) for field in key_fields) or "n/a"
+    print(f"Primary key: {key_display}")
+    candidates = payload.get("key_candidates") or []
+    if candidates:
+        printable = [
+            ", ".join(str(field) for field in candidate if field) or ROW_INDEX_FIELD
+            for candidate in candidates
+        ]
+        print("Key candidates: " + "; ".join(printable))
+    duplicates = payload.get("duplicate_handling", {})
+    if isinstance(duplicates, dict) and duplicates.get("resolved"):
         detail = duplicates.get("details") or "fallback key applied"
         print(f"Duplicate handling: {detail}")
     else:
         print("Duplicate handling: primary key unique")
-    print(f"Namespaces detected: {'yes' if meta.get('namespace_detected') else 'no'}")
-    key_candidates = setup.explain.get("key_candidates")
-    if key_candidates:
-        printable = [", ".join(candidate) for candidate in key_candidates]
-        print("Key candidates tried: " + "; ".join(printable))
-    if setup.warnings:
+    namespaces_detected = "yes" if payload.get("namespaces_detected") else "no"
+    print(f"Namespaces detected: {namespaces_detected}")
+    if payload.get("schema_mismatch"):
+        mismatch = payload["schema_mismatch"]
+        before_schema = mismatch.get("before") if isinstance(mismatch, dict) else mismatch
+        after_schema = mismatch.get("after") if isinstance(mismatch, dict) else mismatch
+        print(f"Schema mismatch: before={before_schema} after={after_schema}")
+    warnings = payload.get("warnings") or []
+    if warnings:
         print("Warnings:")
-        for warning in setup.warnings:
+        for warning in warnings:
             print(f"  - {warning}")
 
 

--- a/src/serdiff/config.py
+++ b/src/serdiff/config.py
@@ -1,0 +1,70 @@
+"""Configuration loading helpers for ser-diff."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - fallback for Python < 3.11
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - fallback import
+    import tomli as tomllib  # type: ignore[no-redef]
+
+import yaml
+
+CONFIG_FILENAMES = [".serdiff.toml", ".serdiff.yaml", ".serdiff.yml", ".serdiff.json"]
+
+
+@dataclass(slots=True)
+class LoadedConfig:
+    """Container for a configuration file discovered on disk."""
+
+    path: Path | None
+    data: dict[str, Any]
+
+    @property
+    def exists(self) -> bool:
+        return self.path is not None
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError("YAML configuration must be a mapping at the top level")
+    return loaded
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError("JSON configuration must be a mapping at the top level")
+    return loaded
+
+
+def load_config(base_dir: Path | None = None) -> LoadedConfig:
+    """Load configuration from disk using precedence TOML > YAML > JSON."""
+
+    search_root = base_dir or Path.cwd()
+
+    for name in CONFIG_FILENAMES:
+        candidate = search_root / name
+        if not candidate.exists():
+            continue
+        if candidate.suffix == ".toml":
+            data = _load_toml(candidate)
+        elif candidate.suffix in {".yaml", ".yml"}:
+            data = _load_yaml(candidate)
+        else:
+            data = _load_json(candidate)
+        if not isinstance(data, dict):
+            raise ValueError("Configuration must be a mapping at the top level")
+        return LoadedConfig(path=candidate, data=data)
+
+    return LoadedConfig(path=None, data={})

--- a/src/serdiff/diff.py
+++ b/src/serdiff/diff.py
@@ -11,7 +11,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from . import __version__
 from .detect import ROW_INDEX_FIELD
+from .report_html import render_html_report
+from .report_xlsx import write_xlsx_report
 
 
 def _local_name(tag: str | None) -> str:
@@ -369,6 +372,9 @@ def diff_files(
             {"role": "before", "path": str(before), "sha256": _compute_hash(before)},
             {"role": "after", "path": str(after), "sha256": _compute_hash(after)},
         ],
+        "before_file": str(before),
+        "after_file": str(after),
+        "tool_version": __version__,
     }
 
     return DiffResult(
@@ -381,26 +387,131 @@ def diff_files(
     )
 
 
-def write_reports(result: DiffResult, out_prefix: Path, *, output_format: str = "all") -> list[str]:
-    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+def build_canonical_payload(
+    result: DiffResult, thresholds: dict[str, object] | None = None
+) -> dict[str, object]:
+    thresholds = thresholds or {}
+    summary = result.summary
+    meta = result.meta
+
+    table_value = meta.get("table") or meta.get("schema") or "CUSTOM"
+    if isinstance(table_value, str) and table_value.upper() == "UNKNOWN":
+        table_value = "CUSTOM"
+
+    key_fields = meta.get("key_fields_used") or []
+    if not isinstance(key_fields, list):
+        key_fields = list(key_fields)
+
+    before_file = meta.get("before_file")
+    after_file = meta.get("after_file")
+    if not before_file or not after_file:
+        for entry in meta.get("input_files", []):
+            if entry.get("role") == "before" and not before_file:
+                before_file = entry.get("path")
+            if entry.get("role") == "after" and not after_file:
+                after_file = entry.get("path")
+
+    def _build_changes(record: dict[str, object]) -> dict[str, dict[str, str]]:
+        delta: dict[str, dict[str, str]] = {}
+        for field_name, change in record.get("changes", {}).items():
+            before_value = change.get("before", "")
+            after_value = change.get("after", "")
+            delta[field_name] = {"from": before_value, "to": after_value}
+        return delta
+
+    payload_meta: dict[str, object] = {
+        "generated_at": meta.get("generated_at"),
+        "tool_version": meta.get("tool_version", __version__),
+        "table": table_value,
+        "key_fields": key_fields,
+        "before_file": before_file,
+        "after_file": after_file,
+        "jira": meta.get("jira"),
+    }
+
+    if meta.get("schema"):
+        payload_meta["schema"] = meta.get("schema")
+    if meta.get("duplicates_resolved") is not None:
+        payload_meta["duplicates_resolved"] = meta.get("duplicates_resolved")
+    if meta.get("namespace_detected") is not None:
+        payload_meta["namespace_detected"] = meta.get("namespace_detected")
+    if meta.get("fields_used"):
+        payload_meta["fields_used"] = meta.get("fields_used")
+    if meta.get("key_fields_used"):
+        payload_meta["key_fields_used"] = meta.get("key_fields_used")
+
+    payload = {
+        "schema_version": "1.0",
+        "meta": payload_meta,
+        "summary": {
+            "added": summary.get("added", 0),
+            "removed": summary.get("removed", 0),
+            "changed": summary.get("updated", 0),
+            "total_before": summary.get("total_before", 0),
+            "total_after": summary.get("total_after", 0),
+            "unexpected_partners": list(result.unexpected_partners),
+            "thresholds": {
+                "max_added": thresholds.get("max_added"),
+                "max_removed": thresholds.get("max_removed"),
+                "violations": list(thresholds.get("violations", [])),
+            },
+        },
+        "added": [
+            {"key": record.get("key"), "record": record.get("after", {})} for record in result.added
+        ],
+        "removed": [
+            {"key": record.get("key"), "record": record.get("before", {})}
+            for record in result.removed
+        ],
+        "changed": [
+            {
+                "key": record.get("key"),
+                "before": record.get("before", {}),
+                "after": record.get("after", {}),
+                "delta": _build_changes(record),
+            }
+            for record in result.updated
+        ],
+    }
+
+    return payload
+
+
+def write_reports(
+    result: DiffResult,
+    out_prefix: Path,
+    *,
+    output_format: str = "all",
+    report_type: str | None = None,
+    thresholds: dict[str, object] | None = None,
+) -> list[str]:
+    out_prefix.mkdir(parents=True, exist_ok=True)
     produced: list[str] = []
 
-    if output_format in {"all", "json"}:
-        json_path = out_prefix.with_suffix(".json")
-        payload = {
-            "summary": result.summary,
-            "meta": result.meta,
-            "added": result.added,
-            "removed": result.removed,
-            "updated": result.updated,
-            "unexpected_partners": result.unexpected_partners,
-        }
-        with json_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2)
-        produced.append(str(json_path))
+    json_path = out_prefix / "diff.json"
+    payload = build_canonical_payload(result, thresholds)
+    with json_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+    produced.append(str(json_path))
 
-    if output_format in {"all", "csv"}:
-        produced.extend(_write_csv_reports(result, out_prefix))
+    if report_type == "html":
+        html_path = out_prefix / f"{out_prefix.name}.html"
+        html = render_html_report(result, payload, thresholds or {})
+        html_path.write_text(html, encoding="utf-8")
+        produced.append(str(html_path))
+
+    if report_type == "xlsx":
+        xlsx_path = out_prefix / f"{out_prefix.name}.xlsx"
+        write_xlsx_report(result, payload, xlsx_path)
+        produced.append(str(xlsx_path))
+
+    generate_csv = output_format in {"all", "csv"}
+    if report_type == "xlsx" and output_format == "all":
+        generate_csv = False
+
+    if generate_csv:
+        csv_prefix = out_prefix / out_prefix.name
+        produced.extend(_write_csv_reports(result, csv_prefix))
 
     result.output_files = produced
     return produced

--- a/src/serdiff/report_html.py
+++ b/src/serdiff/report_html.py
@@ -1,0 +1,438 @@
+"""HTML report rendering for ser-diff."""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .diff import DiffResult
+
+
+def safe_json_for_script(payload: dict[str, object]) -> str:
+    """Serialise JSON for embedding inside a ``<script type="application/json">`` tag."""
+
+    serialised = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    serialised = serialised.replace("</", "<\\/")
+    serialised = serialised.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    return serialised
+
+
+def _escape(value: object) -> str:
+    if value is None:
+        return ""
+    return html.escape(str(value))
+
+
+def _collect_columns(result: DiffResult) -> list[str]:
+    meta = result.meta
+    ordered: list[str] = []
+
+    for field in meta.get("key_fields_used", []) or []:
+        if field and field not in ordered:
+            ordered.append(field)
+
+    for field in meta.get("fields_used", []) or []:
+        if field and field not in ordered:
+            ordered.append(field)
+
+    sources = []
+    sources.extend(entry.get("after", {}) for entry in result.added)
+    sources.extend(entry.get("before", {}) for entry in result.removed)
+    for entry in result.updated:
+        sources.append(entry.get("before", {}))
+        sources.append(entry.get("after", {}))
+
+    for record in sources:
+        if not isinstance(record, dict):
+            continue
+        for field in record:
+            if field and field not in ordered:
+                ordered.append(field)
+
+    return ordered
+
+
+def _render_table_header(columns: list[str]) -> str:
+    headers = ['<th scope="col">Key</th>']
+    headers.extend(f'<th scope="col">{_escape(column)}</th>' for column in columns)
+    return "".join(headers)
+
+
+def _render_record_row(entry: dict[str, object], columns: list[str], *, record_key: str) -> str:
+    key_cell = f"<td class=\"cell-key\">{_escape(entry.get('key'))}</td>"
+    record = entry.get(record_key, {})
+    values: list[str] = []
+    if isinstance(record, dict):
+        for column in columns:
+            values.append(_escape(record.get(column, "")))
+    else:
+        values.extend("" for _ in columns)
+    return key_cell + "".join(f"<td>{value}</td>" for value in values)
+
+
+def _render_change_rows(entry: dict[str, object]) -> str:
+    key = _escape(entry.get("key"))
+    changes = entry.get("changes", {})
+    if not isinstance(changes, dict) or not changes:
+        before = entry.get("before", {})
+        after = entry.get("after", {})
+        return "".join(
+            f'<tr><td class="cell-key">{key}</td><td>{_escape(field)}</td>'
+            f"<td>{_escape(before.get(field, ''))}</td>"
+            f"<td>{_escape(after.get(field, ''))}</td></tr>"
+            for field in sorted(set(before) | set(after))
+        )
+
+    rows: list[str] = []
+    for field, delta in sorted(changes.items()):
+        before_value = ""
+        after_value = ""
+        if isinstance(delta, dict):
+            before_value = delta.get("before") or delta.get("from", "")
+            after_value = delta.get("after") or delta.get("to", "")
+        rows.append(
+            "<tr>"
+            f'<td class="cell-key">{key}</td>'
+            f"<td>{_escape(field)}</td>"
+            f"<td>{_escape(before_value)}</td>"
+            f"<td>{_escape(after_value)}</td>"
+            "</tr>"
+        )
+    return "".join(rows)
+
+
+def _build_diagnostics(result: DiffResult, thresholds: dict[str, object]) -> list[str]:
+    messages: list[str] = []
+
+    violations = thresholds.get("violations") or []
+    violation_map = {
+        "MAX_ADDED": "Added records exceeded the configured maximum.",
+        "MAX_REMOVED": "Removed records exceeded the configured maximum.",
+        "UNEXPECTED_PARTNER": "Unexpected partners were found in the dataset.",
+    }
+    for violation in violations:
+        message = violation_map.get(str(violation), f"Threshold violation: {violation}")
+        messages.append(message)
+
+    if result.unexpected_partners:
+        partners = ", ".join(str(partner) for partner in result.unexpected_partners)
+        messages.append(f"Unexpected partners detected: {partners}")
+
+    duplicates = result.meta.get("duplicates_resolved", {})
+    if isinstance(duplicates, dict) and duplicates.get("resolved"):
+        detail = duplicates.get("details") or "Fallback key applied for uniqueness."
+        messages.append(f"Duplicate keys were resolved automatically ({detail}).")
+
+    if result.meta.get("namespace_detected"):
+        messages.append("XML namespaces were detected in the source documents.")
+
+    return messages
+
+
+def render_html_report(
+    result: DiffResult, payload: dict[str, object], thresholds: dict[str, object]
+) -> str:
+    """Render a single-file HTML report for the provided diff result."""
+
+    meta = result.meta
+    summary = payload.get("summary", {}) if isinstance(payload, dict) else {}
+    table_label = meta.get("table") or meta.get("schema") or "SER Diff"
+    title = f"ser-diff report – {table_label}"
+
+    columns = _collect_columns(result)
+
+    before_file = meta.get("before_file")
+    after_file = meta.get("after_file")
+    if not before_file:
+        files = meta.get("input_files", [])
+        if isinstance(files, list) and files:
+            first = files[0]
+            if isinstance(first, dict):
+                before_file = first.get("path")
+    if not after_file:
+        files = meta.get("input_files", [])
+        if isinstance(files, list):
+            for entry in files:
+                if isinstance(entry, dict) and entry.get("role") == "after":
+                    after_file = entry.get("path")
+                    break
+    partners = meta.get("partners_detected", []) or []
+    expected_partners = meta.get("expected_partners", []) or []
+
+    diagnostics = _build_diagnostics(result, thresholds)
+
+    summary_cards = "".join(
+        '<div class="summary-card">'
+        f'<span class="summary-label">{label}</span>'
+        f'<span class="badge">{value}</span>'
+        "</div>"
+        for label, value in [
+            ("Added", summary.get("added", 0)),
+            ("Removed", summary.get("removed", 0)),
+            ("Changed", summary.get("changed", summary.get("updated", 0))),
+            ("Before rows", summary.get("total_before", 0)),
+            ("After rows", summary.get("total_after", 0)),
+        ]
+    )
+
+    threshold_badges = []
+    if thresholds.get("max_added") is not None:
+        threshold_badges.append(
+            f'<div class="summary-card"><span class="summary-label">Max added</span>'
+            f"<span class=\"badge badge-muted\">{thresholds['max_added']}</span></div>"
+        )
+    if thresholds.get("max_removed") is not None:
+        threshold_badges.append(
+            f'<div class="summary-card"><span class="summary-label">Max removed</span>'
+            f"<span class=\"badge badge-muted\">{thresholds['max_removed']}</span></div>"
+        )
+    if thresholds.get("violations"):
+        threshold_badges.append(
+            '<div class="summary-card alert"><span class="summary-label">Violations</span>'
+            f"<span class=\"badge badge-alert\">{len(thresholds['violations'])}</span></div>"
+        )
+
+    header_rows = [
+        ("Before file", before_file or ""),
+        ("After file", after_file or ""),
+        ("Generated at", meta.get("generated_at", "")),
+        ("Tool version", meta.get("tool_version", "")),
+        ("Schema", meta.get("schema", "")),
+        ("Key fields", ", ".join(meta.get("key_fields_used", [])) or "n/a"),
+        ("Record path", meta.get("record_path", "")),
+        ("Record localname", meta.get("record_localname", "")),
+        ("Jira ticket", meta.get("jira", "")),
+    ]
+
+    partner_section = (
+        "".join('<div class="chip">' + _escape(partner) + "</div>" for partner in partners)
+        or "<em>None detected</em>"
+    )
+
+    expected_section = (
+        "".join(
+            '<div class="chip muted">' + _escape(partner) + "</div>"
+            for partner in expected_partners
+        )
+        or "<em>Not configured</em>"
+    )
+
+    added_rows = "".join(
+        f"<tr>{_render_record_row(entry, columns, record_key='after')}</tr>"
+        for entry in result.added
+    )
+    removed_rows = "".join(
+        f"<tr>{_render_record_row(entry, columns, record_key='before')}</tr>"
+        for entry in result.removed
+    )
+    changed_rows = "".join(_render_change_rows(entry) for entry in result.updated)
+
+    added_empty = f'<tr><td colspan="{len(columns) + 1}"><em>No added records.</em></td></tr>'
+    removed_empty = f'<tr><td colspan="{len(columns) + 1}"><em>No removed records.</em></td></tr>'
+    changed_empty = '<tr><td colspan="4"><em>No changed fields.</em></td></tr>'
+
+    diagnostics_block = (
+        "<ul>" + "".join(f"<li>{_escape(message)}</li>" for message in diagnostics) + "</ul>"
+        if diagnostics
+        else "<p>No diagnostics were generated for this run.</p>"
+    )
+
+    html_parts = [
+        "<!DOCTYPE html>",
+        '<html lang="en">',
+        "<head>",
+        '  <meta charset="utf-8">',
+        '  <meta http-equiv="Content-Security-Policy" '
+        "content=\"default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'\">",
+        f"  <title>{_escape(title)}</title>",
+        "  <style>",
+        "    :root { color-scheme: light dark; font-family: 'Inter', 'Segoe UI', sans-serif; }",
+        "    body { margin: 0; padding: 1.5rem; background: #f8fafc; color: #0f172a; }",
+        "    h1, h2, h3 { margin: 0; font-weight: 600; }",
+        "    h2 { margin-top: 2.5rem; margin-bottom: 1rem; font-size: 1.5rem; }",
+        "    h3 { margin-top: 2rem; margin-bottom: 0.75rem; font-size: 1.2rem; }",
+        "    p { line-height: 1.6; }",
+        "    a { color: #1d4ed8; }",
+        "    .container { max-width: 1200px; margin: 0 auto; }",
+        "    .header { background: #1d4ed8; color: #fff; padding: 1.5rem; border-radius: 1rem; }",
+        "    .header dl { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 0.75rem; margin: 1.5rem 0 0; }",
+        "    .header dt { font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.8; }",
+        "    .header dd { margin: 0; font-size: 0.95rem; }",
+        "    .summary-grid { display: flex; flex-wrap: wrap; gap: 1rem; }",
+        "    .summary-card { background: #fff; border-radius: 0.75rem; padding: 1rem 1.25rem; box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12); min-width: 160px; }",
+        "    .summary-card.alert { background: #fee2e2; }",
+        "    .summary-label { display: block; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; color: #475569; margin-bottom: 0.5rem; }",
+        "    .badge { display: inline-block; padding: 0.25rem 0.75rem; border-radius: 999px; font-weight: 600; background: #1d4ed8; color: #fff; }",
+        "    .badge-muted { background: #e2e8f0; color: #1e293b; }",
+        "    .badge-alert { background: #b91c1c; }",
+        "    .chip { display: inline-flex; align-items: center; padding: 0.25rem 0.75rem; border-radius: 999px; background: #e0f2fe; color: #0369a1; font-size: 0.85rem; margin: 0.25rem; }",
+        "    .chip.muted { background: #e2e8f0; color: #475569; }",
+        "    .section { margin-top: 2.5rem; }",
+        "    table { width: 100%; border-collapse: collapse; margin-top: 0.75rem; background: #fff; border-radius: 0.75rem; overflow: hidden; box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08); }",
+        "    table caption { text-align: left; font-weight: 600; padding: 1rem 1.25rem 0; font-size: 1.1rem; }",
+        "    th, td { padding: 0.6rem 0.75rem; border-bottom: 1px solid #e2e8f0; text-align: left; vertical-align: top; }",
+        "    thead th { position: sticky; top: 0; background: #f1f5f9; z-index: 2; cursor: pointer; }",
+        "    tbody tr:nth-child(odd) { background: rgba(241, 245, 249, 0.5); }",
+        "    .table-wrapper { overflow-x: auto; border-radius: 0.75rem; }",
+        "    .table-controls { display: flex; justify-content: flex-end; margin-top: 0.5rem; }",
+        "    .table-controls input { padding: 0.4rem 0.6rem; border-radius: 0.5rem; border: 1px solid #cbd5f5; min-width: 220px; }",
+        "    .cell-key { font-family: 'JetBrains Mono', 'Fira Mono', monospace; font-size: 0.85rem; white-space: nowrap; }",
+        "    footer { margin: 3rem 0 1rem; text-align: center; color: #64748b; font-size: 0.85rem; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        '  <div class="container">',
+        '    <header class="header">',
+        "      <h1>ser-diff comparison report</h1>",
+        f"      <p>Table: {_escape(table_label)}</p>",
+        "      <dl>",
+    ]
+
+    for label, value in header_rows:
+        html_parts.append(f"        <dt>{_escape(label)}</dt>")
+        html_parts.append(f"        <dd>{_escape(value)}</dd>")
+
+    html_parts.extend(
+        [
+            "      </dl>",
+            "    </header>",
+            '    <section class="section">',
+            "      <h2>Summary</h2>",
+            f'      <div class="summary-grid">{summary_cards}</div>',
+        ]
+    )
+
+    if threshold_badges:
+        html_parts.append(
+            '      <div class="summary-grid" style="margin-top:1rem;">'
+            + "".join(threshold_badges)
+            + "</div>"
+        )
+
+    html_parts.extend(
+        [
+            "      <h3>Partners</h3>",
+            f"      <div>{partner_section}</div>",
+            "      <h3>Expected partners</h3>",
+            f"      <div>{expected_section}</div>",
+            "    </section>",
+        ]
+    )
+
+    html_parts.extend(
+        [
+            '    <section class="section">',
+            "      <h2>Added records</h2>",
+            '      <div class="table-controls"><input type="search" placeholder="Filter rows..." data-table-filter="table-added"></div>',
+            '      <div class="table-wrapper">',
+            '        <table id="table-added" class="sortable">',
+            "          <thead><tr>",
+            _render_table_header(columns),
+            "          </tr></thead>",
+            f"          <tbody>{added_rows or added_empty}</tbody>",
+            "        </table>",
+            "      </div>",
+            "    </section>",
+        ]
+    )
+
+    html_parts.extend(
+        [
+            '    <section class="section">',
+            "      <h2>Removed records</h2>",
+            '      <div class="table-controls"><input type="search" placeholder="Filter rows..." data-table-filter="table-removed"></div>',
+            '      <div class="table-wrapper">',
+            '        <table id="table-removed" class="sortable">',
+            "          <thead><tr>",
+            _render_table_header(columns),
+            "          </tr></thead>",
+            f"          <tbody>{removed_rows or removed_empty}</tbody>",
+            "        </table>",
+            "      </div>",
+            "    </section>",
+        ]
+    )
+
+    html_parts.extend(
+        [
+            '    <section class="section">',
+            "      <h2>Changed fields</h2>",
+            '      <div class="table-controls"><input type="search" placeholder="Filter rows..." data-table-filter="table-changed"></div>',
+            '      <div class="table-wrapper">',
+            '        <table id="table-changed" class="sortable">',
+            '          <thead><tr><th scope="col">Key</th><th scope="col">Field</th><th scope="col">Before</th><th scope="col">After</th></tr></thead>',
+            f"          <tbody>{changed_rows or changed_empty}</tbody>",
+            "        </table>",
+            "      </div>",
+            "    </section>",
+        ]
+    )
+
+    html_parts.extend(
+        [
+            '    <section class="section">',
+            "      <h2>Diagnostics</h2>",
+            f"      {diagnostics_block}",
+            "    </section>",
+            "    <footer>Generated by ser-diff. View canonical payload via the embedded JSON script tag.</footer>",
+        ]
+    )
+
+    html_parts.extend(
+        [
+            "  </div>",
+            f'  <script type="application/json" id="ser-diff-data">{safe_json_for_script(payload)}</script>',
+            "  <script>",
+            "    (function() {",
+            "      const dataEl = document.getElementById('ser-diff-data');",
+            "      if (dataEl) {",
+            "        try {",
+            "          window.serDiffPayload = JSON.parse(dataEl.textContent);",
+            "        } catch (error) {",
+            "          console.error('Failed to parse embedded payload', error);",
+            "        }",
+            "      }",
+            "      const filters = document.querySelectorAll('[data-table-filter]');",
+            "      filters.forEach((input) => {",
+            "        input.addEventListener('input', () => {",
+            "          const targetId = input.getAttribute('data-table-filter');",
+            "          const term = input.value.trim().toLowerCase();",
+            "          const table = document.getElementById(targetId);",
+            "          if (!table) { return; }",
+            "          table.querySelectorAll('tbody tr').forEach((row) => {",
+            "            const text = row.textContent.toLowerCase();",
+            "            row.style.display = term === '' || text.includes(term) ? '' : 'none';",
+            "          });",
+            "        });",
+            "      });",
+            "      document.querySelectorAll('table.sortable thead th').forEach((th, index) => {",
+            "        th.addEventListener('click', () => {",
+            "          const table = th.closest('table');",
+            "          const tbody = table.querySelector('tbody');",
+            "          const rows = Array.from(tbody.querySelectorAll('tr'));",
+            "          const ascending = th.dataset.sort !== 'asc';",
+            "          rows.sort((a, b) => {",
+            "            const av = a.children[index].textContent.trim();",
+            "            const bv = b.children[index].textContent.trim();",
+            "            const aNum = Number(av.replace(/[^0-9.-]+/g, ''));",
+            "            const bNum = Number(bv.replace(/[^0-9.-]+/g, ''));",
+            "            if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {",
+            "              return ascending ? aNum - bNum : bNum - aNum;",
+            "            }",
+            "            return ascending ? av.localeCompare(bv) : bv.localeCompare(av);",
+            "          });",
+            "          rows.forEach((row) => tbody.appendChild(row));",
+            "          table.querySelectorAll('th').forEach((header) => { header.dataset.sort = ''; });",
+            "          th.dataset.sort = ascending ? 'asc' : 'desc';",
+            "        });",
+            "      });",
+            "    })();",
+            "  </script>",
+            "</body>",
+            "</html>",
+        ]
+    )
+
+    return "\n".join(html_parts)

--- a/src/serdiff/report_xlsx.py
+++ b/src/serdiff/report_xlsx.py
@@ -1,0 +1,130 @@
+"""Utilities for rendering single-file XLSX reports."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from os import PathLike
+from typing import TYPE_CHECKING, Any, BinaryIO
+
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from .diff import DiffResult
+
+
+def _append_rows(ws, rows: Iterable[tuple[Any, ...]]) -> None:
+    for row in rows:
+        ws.append(list(row))
+
+
+def _set_table_formatting(ws) -> None:  # type: ignore[no-untyped-def]
+    ws.freeze_panes = "A2"
+    last_column = get_column_letter(ws.max_column or 1)
+    last_row = ws.max_row or 1
+    ws.auto_filter.ref = f"A1:{last_column}{last_row}"
+
+
+def _format_summary_sheet(ws, payload: dict[str, Any]) -> None:  # type: ignore[no-untyped-def]
+    meta = payload.get("meta", {})
+    summary = payload.get("summary", {})
+    thresholds = summary.get("thresholds", {})
+
+    rows = [
+        ("Metric", "Value"),
+        ("Table", meta.get("table", "")),
+        ("Schema", meta.get("schema", "")),
+        ("Before file", meta.get("before_file", "")),
+        ("After file", meta.get("after_file", "")),
+        ("Jira", meta.get("jira", "")),
+        ("Added", summary.get("added", 0)),
+        ("Removed", summary.get("removed", 0)),
+        ("Changed", summary.get("changed", 0)),
+        ("Total before", summary.get("total_before", 0)),
+        ("Total after", summary.get("total_after", 0)),
+        (
+            "Unexpected partners",
+            ", ".join(summary.get("unexpected_partners", [])) or "None",
+        ),
+        ("Max added", thresholds.get("max_added", "")),
+        ("Max removed", thresholds.get("max_removed", "")),
+        (
+            "Threshold violations",
+            ", ".join(thresholds.get("violations", [])) or "None",
+        ),
+    ]
+
+    _append_rows(ws, rows)
+    _set_table_formatting(ws)
+
+
+def _collect_headers(records: list[dict[str, Any]], key: str) -> list[str]:
+    headers: list[str] = ["key"]
+    for record in records:
+        section = record.get(key, {})
+        if not isinstance(section, dict):
+            continue
+        for field_name in section:
+            if field_name not in headers:
+                headers.append(field_name)
+    return headers
+
+
+def _write_record_sheet(ws, records: list[dict[str, Any]], section_key: str) -> None:  # type: ignore[no-untyped-def]
+    headers = _collect_headers(records, section_key)
+    ws.append(headers)
+    for record in records:
+        row = [record.get("key", "")]
+        section = record.get(section_key, {})
+        values = section if isinstance(section, dict) else {}
+        for header in headers[1:]:
+            row.append(values.get(header, ""))
+        ws.append(row)
+    _set_table_formatting(ws)
+
+
+def _write_changed_sheet(ws, records: list[dict[str, Any]]) -> None:  # type: ignore[no-untyped-def]
+    ws.append(["key", "field", "before", "after"])
+    for record in records:
+        changes = record.get("changes", {})
+        if not isinstance(changes, dict):
+            continue
+        for field_name, change in sorted(changes.items()):
+            before_value = ""
+            after_value = ""
+            if isinstance(change, dict):
+                before_value = change.get("before", "")
+                after_value = change.get("after", "")
+            ws.append([record.get("key", ""), field_name, before_value, after_value])
+    _set_table_formatting(ws)
+
+
+def render_xlsx_report(result: DiffResult, payload: dict[str, Any]) -> Workbook:
+    """Create an openpyxl workbook representing the diff result."""
+
+    workbook = Workbook()
+    summary_ws = workbook.active
+    summary_ws.title = "Summary"
+    _format_summary_sheet(summary_ws, payload)
+
+    added_ws = workbook.create_sheet("Added")
+    _write_record_sheet(added_ws, result.added, "after")
+
+    removed_ws = workbook.create_sheet("Removed")
+    _write_record_sheet(removed_ws, result.removed, "before")
+
+    changed_ws = workbook.create_sheet("Changed")
+    _write_changed_sheet(changed_ws, result.updated)
+
+    return workbook
+
+
+def write_xlsx_report(
+    result: DiffResult,
+    payload: dict[str, Any],
+    destination: BinaryIO | PathLike[str] | str,
+) -> None:
+    """Render the XLSX workbook and write it to a file-like object or path."""
+
+    workbook = render_xlsx_report(result, payload)
+    workbook.save(destination)

--- a/tests/test_auto_key_fallback_duplicates.py
+++ b/tests/test_auto_key_fallback_duplicates.py
@@ -61,9 +61,10 @@ def test_auto_mode_extends_key_for_duplicates(tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == cli.EXIT_SUCCESS
-    assert "Diff: added=0" in captured.out
+    assert "Diff summary | added: 0" in captured.out
 
-    report = tmp_path / "auto-dup.json"
+    report_dir = tmp_path / "auto-dup"
+    report = report_dir / "diff.json"
     data = json.loads(report.read_text(encoding="utf-8"))
     assert data["summary"]["total_before"] == 2
     assert data["meta"]["duplicates_resolved"]["resolved"] is True

--- a/tests/test_auto_mode_ser_ns.py
+++ b/tests/test_auto_mode_ser_ns.py
@@ -28,9 +28,10 @@ def test_auto_mode_handles_namespaced_ser(tmp_path: Path, capsys) -> None:
 
     captured = capsys.readouterr()
     assert exit_code == cli.EXIT_SUCCESS
-    assert "Diff: added=1" in captured.out
+    assert "Diff summary | added: 1" in captured.out
 
-    report = tmp_path / "auto-ser.json"
+    report_dir = tmp_path / "auto-ser"
+    report = report_dir / "diff.json"
     data = json.loads(report.read_text(encoding="utf-8"))
     assert data["summary"]["total_before"] == 2
     assert data["summary"]["total_after"] == 2

--- a/tests/test_canonical_json.py
+++ b/tests/test_canonical_json.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+from serdiff import __version__, cli
+from serdiff.diff import diff_files, write_reports
+from serdiff.presets import get_preset
+
+
+def write_xml(path: Path, body: str) -> Path:
+    path.write_text(body.strip(), encoding="utf-8")
+    return path
+
+
+def test_canonical_json_schema_and_delta(tmp_path: Path) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+          </ExposureType>
+          <ExposureType>
+            <PublicID>EXP-002</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Lyft</Partner>
+            <State>CA</State>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Uber</Partner>
+            <State>CA</State>
+            <EffectiveDate>2023-01-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+          </ExposureType>
+          <ExposureType>
+            <PublicID>EXP-003</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>DoorDash</Partner>
+            <State>TX</State>
+            <EffectiveDate>2023-06-01</EffectiveDate>
+            <ExpirationDate>2023-12-31</ExpirationDate>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+
+    preset = get_preset("EXPOSURE")
+    result = diff_files(
+        before,
+        after,
+        preset.config,
+        jira="MOB-123",
+        expected_partners=["Uber"],
+    )
+
+    thresholds, _ = cli._evaluate_thresholds(
+        result,
+        expected_partners=["Uber"],
+        max_added=0,
+        max_removed=0,
+    )
+
+    out_dir = tmp_path / "reports" / "run"
+    produced = write_reports(result, out_dir, output_format="json", thresholds=thresholds)
+
+    json_path = out_dir / "diff.json"
+    assert str(json_path) in produced
+
+    with json_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    assert payload["schema_version"] == "1.0"
+
+    meta = payload["meta"]
+    assert meta["tool_version"] == __version__
+    assert meta["table"] == "EXPOSURE"
+    assert meta["jira"] == "MOB-123"
+    assert meta["before_file"].endswith("before.xml")
+    assert meta["after_file"].endswith("after.xml")
+    assert meta["key_fields"] == ["PublicID"]
+    assert "generated_at" in meta and meta["generated_at"]
+
+    summary = payload["summary"]
+    assert summary["added"] == 1
+    assert summary["removed"] == 1
+    assert summary["changed"] == 1
+    assert set(summary["unexpected_partners"]) == {"Lyft", "DoorDash"}
+
+    thresholds_summary = summary["thresholds"]
+    assert thresholds_summary["max_added"] == 0
+    assert thresholds_summary["max_removed"] == 0
+    assert {"MAX_ADDED", "MAX_REMOVED", "UNEXPECTED_PARTNER"}.issubset(
+        set(thresholds_summary["violations"])
+    )
+
+    added_records = payload["added"]
+    assert added_records[0]["record"]["PublicID"] == "EXP-003"
+
+    removed_records = payload["removed"]
+    assert removed_records[0]["record"]["PublicID"] == "EXP-002"
+
+    changed_records = payload["changed"]
+    assert changed_records[0]["delta"]["State"] == {"from": "NY", "to": "CA"}
+    assert changed_records[0]["before"]["State"] == "NY"
+    assert changed_records[0]["after"]["State"] == "CA"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def write_xml(path: Path, body: str) -> Path:
     return path
 
 
-def test_cli_threshold_failure(tmp_path: Path) -> None:
+def test_cli_threshold_failure(tmp_path: Path, capsys) -> None:
     before = write_xml(
         tmp_path / "before.xml",
         """
@@ -79,10 +79,19 @@ def test_cli_threshold_failure(tmp_path: Path) -> None:
             str(tmp_path),
             "--out-prefix",
             "report",
+            "--report",
+            "html",
         ]
     )
 
     assert exit_code == cli.EXIT_GATES_FAILED
+    captured = capsys.readouterr()
+    assert "Diff summary | added:" in captured.out
+    assert "Warning:" in captured.err
+
+    report_dir = tmp_path / "report"
+    assert (report_dir / "diff.json").exists()
+    assert any(path.suffix == ".html" for path in report_dir.iterdir())
 
 
 def test_expected_partner_detection(tmp_path: Path) -> None:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,109 @@
+"""Tests for configuration loading and CLI overrides."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from serdiff import cli
+from serdiff.config import load_config
+
+
+def test_load_config_precedence(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / ".serdiff.json").write_text('{"jira": {"ticket": "JSON"}}', encoding="utf-8")
+    (tmp_path / ".serdiff.yaml").write_text("jira:\n  ticket: YAML", encoding="utf-8")
+    (tmp_path / ".serdiff.toml").write_text("[jira]\nticket = 'TOML'\n", encoding="utf-8")
+
+    loaded = load_config(Path.cwd())
+
+    assert loaded.path == tmp_path / ".serdiff.toml"
+    assert loaded.data["jira"]["ticket"] == "TOML"
+
+
+def test_cli_config_application_and_override(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    config_content = textwrap.dedent(
+        """
+        [jira]
+        ticket = "SER-1234"
+
+        [io]
+        output_dir = "configured-reports"
+        out_prefix = "configured"
+
+        [guards]
+        expected_partners = ["Alpha", "Beta"]
+        max_added = 5
+        max_removed = 2
+        fail_on_unexpected = true
+
+        [preset]
+        mode = "custom"
+
+        [custom]
+        record_path = "./Custom"
+        record_localname = "Custom"
+        keys = ["Id"]
+        fields = ["Id", "Name"]
+        strip_ns = true
+        """
+    ).strip()
+
+    (tmp_path / ".serdiff.toml").write_text(config_content + "\n", encoding="utf-8")
+
+    base_args = cli._parse_args(["--before", "before.xml", "--after", "after.xml"])
+    loaded = load_config(Path.cwd())
+    merged = cli._merge_cli_with_config(base_args, loaded)
+
+    assert merged.jira == "SER-1234"
+    assert merged.output_dir == "configured-reports"
+    assert merged.out_prefix == "configured"
+    assert merged.expected_partners == "Alpha, Beta"
+    assert merged.max_added == 5
+    assert merged.max_removed == 2
+    assert merged.fail_on_unexpected is True
+    assert merged.record_path == "./Custom"
+    assert merged.record_localname == "Custom"
+    assert merged.keys == ["Id"]
+    assert merged.fields == "Id, Name"
+    assert merged.strip_ns is True
+    assert merged.auto is False
+
+    override_args = cli._parse_args(
+        [
+            "--before",
+            "before.xml",
+            "--after",
+            "after.xml",
+            "--output-dir",
+            "cli-reports",
+            "--no-fail-on-unexpected",
+        ]
+    )
+    override_merged = cli._merge_cli_with_config(override_args, loaded)
+
+    assert override_merged.output_dir == "cli-reports"
+    assert override_merged.fail_on_unexpected is False
+
+
+def test_init_creates_template_and_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    first_exit = cli.main(["init"])
+    config_path = tmp_path / ".serdiff.toml"
+    assert first_exit == cli.EXIT_SUCCESS
+    assert config_path.exists()
+
+    content_first = config_path.read_text(encoding="utf-8")
+    assert "# ser-diff configuration template" in content_first
+    assert '# out_prefix = "diff_report"' in content_first
+    assert str((tmp_path / "reports").resolve()) in content_first
+
+    second_exit = cli.main(["init"])
+    content_second = config_path.read_text(encoding="utf-8")
+
+    assert second_exit == cli.EXIT_SUCCESS
+    assert content_first == content_second

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -1,0 +1,44 @@
+"""Tests for the `ser-diff doctor` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from serdiff import cli
+
+
+def test_doctor_happy_path(tmp_path, capsys):
+    exit_code = cli.main(["doctor", "--reports-dir", str(tmp_path)])
+
+    captured = capsys.readouterr().out
+
+    assert exit_code == cli.EXIT_SUCCESS
+    assert "ser-diff version" in captured
+    assert "Python version" in captured
+    assert "Reports directory" in captured
+    assert str(tmp_path) in captured
+    assert "Doctor summary: All systems go." in captured
+
+
+def test_doctor_reports_directory_not_writable(tmp_path, monkeypatch, capsys):
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+
+    original_access = cli.os.access
+
+    def fake_access(path: str | Path, mode: int) -> bool:
+        target = Path(path)
+        if target == reports_dir:
+            return False
+        return original_access(path, mode)
+
+    monkeypatch.setattr(cli.os, "access", fake_access)
+
+    exit_code = cli.main(["doctor", "--reports-dir", str(reports_dir)])
+
+    captured = capsys.readouterr().out
+
+    assert exit_code == cli.EXIT_FAILURE
+    assert "[FAIL] Reports directory" in captured
+    assert "not writable" in captured
+    assert "Issues detected" in captured

--- a/tests/test_explain_output.py
+++ b/tests/test_explain_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from serdiff import cli
@@ -30,5 +31,34 @@ def test_explain_prints_detection_details(tmp_path: Path, capsys) -> None:
     assert exit_code == cli.EXIT_SUCCESS
     assert "Explain" in captured.out
     assert "Schema: SER" in captured.out
-    assert "Key fields:" in captured.out
+    assert "Primary key:" in captured.out
     assert "Namespaces detected: yes" in captured.out
+
+
+def test_explain_subcommand_json(tmp_path: Path, capsys) -> None:
+    before = FIXTURES / "SER_before_ns.xml"
+    after = FIXTURES / "SER_after_ns.xml"
+
+    exit_code = cli.main(
+        [
+            "explain",
+            "--before",
+            str(before),
+            "--after",
+            str(after),
+            "--output-dir",
+            str(tmp_path),
+            "--out-prefix",
+            "explain-json",
+            "--auto",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == cli.EXIT_SUCCESS
+    payload = json.loads(captured.out)
+    assert payload["schema"] == "SER"
+    assert payload["summary"]["total_before"] == 2
+    assert payload["namespaces_detected"] is True
+    assert payload["key_fields"][0] == "AccountNumber"

--- a/tests/test_html_report.py
+++ b/tests/test_html_report.py
@@ -1,0 +1,110 @@
+import json
+import re
+from pathlib import Path
+
+from serdiff import cli
+from serdiff.diff import diff_files, write_reports
+from serdiff.presets import get_preset
+
+
+def write_xml(path: Path, body: str) -> Path:
+    path.write_text(body.strip(), encoding="utf-8")
+    return path
+
+
+def extract_embedded_json(html_text: str) -> dict[str, object]:
+    match = re.search(
+        r"<script type=\"application/json\" id=\"ser-diff-data\">(.*?)</script>",
+        html_text,
+        re.DOTALL,
+    )
+    assert match, "Embedded JSON script tag not found"
+    return json.loads(match.group(1))
+
+
+def test_html_report_contains_canonical_payload(tmp_path: Path) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Lyft</Partner>
+            <State>CA</State>
+          </ExposureType>
+          <ExposureType>
+            <PublicID>EXP-002</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>DoorDash</Partner>
+            <State>TX</State>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+
+    preset = get_preset("EXPOSURE")
+    result = diff_files(
+        before,
+        after,
+        preset.config,
+        jira="MOB-555",
+        expected_partners=["Uber"],
+    )
+
+    thresholds, _ = cli._evaluate_thresholds(
+        result,
+        expected_partners=["Uber"],
+        max_added=0,
+        max_removed=0,
+    )
+
+    out_dir = tmp_path / "reports" / "run"
+    produced = write_reports(
+        result,
+        out_dir,
+        output_format="json",
+        report_type="html",
+        thresholds=thresholds,
+    )
+
+    json_path = out_dir / "diff.json"
+    html_path = out_dir / f"{out_dir.name}.html"
+
+    assert str(json_path) in produced
+    assert str(html_path) in produced
+
+    with json_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    html_text = html_path.read_text(encoding="utf-8")
+    embedded_payload = extract_embedded_json(html_text)
+
+    assert embedded_payload == payload
+
+    summary = payload["summary"]
+    assert (
+        f"<span class=\"summary-label\">Added</span><span class=\"badge\">{summary['added']}</span>"
+        in html_text
+    )
+    assert (
+        f"<span class=\"summary-label\">Removed</span><span class=\"badge\">{summary['removed']}</span>"
+        in html_text
+    )
+    assert (
+        f"<span class=\"summary-label\">Changed</span><span class=\"badge\">{summary['changed']}"
+        in html_text
+    )

--- a/tests/test_report_html_json_embed.py
+++ b/tests/test_report_html_json_embed.py
@@ -1,0 +1,104 @@
+import json
+import re
+
+from serdiff.diff import DiffResult
+from serdiff.report_html import render_html_report
+
+
+def _build_result(value: str) -> tuple[DiffResult, dict[str, object], dict[str, object]]:
+    result = DiffResult(
+        summary={"added": 0, "removed": 0, "updated": 1},
+        meta={
+            "table": "TEST",
+            "schema": "TEST",
+            "generated_at": "2024-01-01T00:00:00Z",
+            "tool_version": "1.0.0",
+            "before_file": "before.xml",
+            "after_file": "after.xml",
+            "key_fields_used": ["PublicID"],
+            "fields_used": ["Value"],
+            "record_path": "/ExposureTypes/ExposureType",
+            "record_localname": "ExposureType",
+            "jira": "MOB-1",
+        },
+        added=[],
+        removed=[],
+        updated=[
+            {
+                "key": "EXP-1",
+                "before": {"Value": value},
+                "after": {"Value": "ok"},
+                "changes": {"Value": {"before": value, "after": "ok"}},
+            }
+        ],
+        unexpected_partners=[],
+    )
+
+    payload = {
+        "schema_version": "1.0",
+        "meta": {
+            "generated_at": "2024-01-01T00:00:00Z",
+            "tool_version": "1.0.0",
+            "table": "TEST",
+            "key_fields": ["PublicID"],
+            "before_file": "before.xml",
+            "after_file": "after.xml",
+            "jira": "MOB-1",
+        },
+        "summary": {
+            "added": 0,
+            "removed": 0,
+            "changed": 1,
+            "unexpected_partners": [],
+            "thresholds": {
+                "max_added": None,
+                "max_removed": None,
+                "violations": [],
+            },
+        },
+        "added": [],
+        "removed": [],
+        "changed": [
+            {
+                "key": "EXP-1",
+                "before": {"Value": value},
+                "after": {"Value": "ok"},
+                "delta": {"Value": {"from": value, "to": "ok"}},
+            }
+        ],
+    }
+
+    thresholds = {"violations": []}
+    return result, payload, thresholds
+
+
+def _extract_payload_text(html: str) -> str:
+    match = re.search(
+        r"<script type=\"application/json\" id=\"ser-diff-data\">(.*?)</script>",
+        html,
+        re.DOTALL,
+    )
+    assert match, "Embedded JSON script tag not found"
+    return match.group(1)
+
+
+def test_json_injected_safely_with_script_ender() -> None:
+    marker = "</script><div id='pwned'>"
+    result, payload, thresholds = _build_result(marker)
+    html = render_html_report(result, payload, thresholds)
+    script_text = _extract_payload_text(html)
+
+    assert "</script>" not in script_text
+
+    round_tripped = json.loads(script_text)
+    assert round_tripped["changed"][0]["before"]["Value"].startswith("</script")
+
+
+def test_json_injected_safely_with_line_separators() -> None:
+    value = "Line1\u2028Line2\u2029End"
+    result, payload, thresholds = _build_result(value)
+    html = render_html_report(result, payload, thresholds)
+    script_text = _extract_payload_text(html)
+
+    round_tripped = json.loads(script_text)
+    assert round_tripped["changed"][0]["before"]["Value"] == value

--- a/tests/test_windows_paths_do_not_break.py
+++ b/tests/test_windows_paths_do_not_break.py
@@ -52,4 +52,6 @@ def test_windows_style_output_dir(tmp_path: Path, capsys, monkeypatch) -> None:
     assert "reports\\windows" in captured.out
     output_dir = Path("reports\\windows")
     assert output_dir.exists()
-    assert (output_dir / "win.json").exists()
+    report_root = output_dir / "win"
+    assert report_root.exists()
+    assert (report_root / "diff.json").exists()

--- a/tests/test_xlsx_report.py
+++ b/tests/test_xlsx_report.py
@@ -1,0 +1,125 @@
+from io import BytesIO
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from serdiff import cli
+from serdiff.diff import build_canonical_payload, diff_files, write_reports
+from serdiff.presets import get_preset
+from serdiff.report_xlsx import write_xlsx_report
+
+
+def write_xml(path: Path, body: str) -> Path:
+    path.write_text(body.strip(), encoding="utf-8")
+    return path
+
+
+def _lookup_summary_value(sheet, label: str) -> str:  # type: ignore[no-untyped-def]
+    for row in sheet.iter_rows(min_row=2, values_only=True):
+        metric = row[0]
+        value = row[1] if len(row) > 1 else None
+        if metric == label:
+            return value
+    raise AssertionError(f"Label {label!r} not found in summary sheet")
+
+
+def test_xlsx_report_generates_expected_workbook(tmp_path: Path) -> None:
+    before = write_xml(
+        tmp_path / "before.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Uber</Partner>
+            <State>NY</State>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+    after = write_xml(
+        tmp_path / "after.xml",
+        """
+        <ExposureTypes>
+          <ExposureType>
+            <PublicID>EXP-001</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>Lyft</Partner>
+            <State>CA</State>
+          </ExposureType>
+          <ExposureType>
+            <PublicID>EXP-002</PublicID>
+            <ExposureCode>AUTO</ExposureCode>
+            <Partner>DoorDash</Partner>
+            <State>TX</State>
+          </ExposureType>
+        </ExposureTypes>
+        """,
+    )
+
+    preset = get_preset("EXPOSURE")
+    result = diff_files(
+        before,
+        after,
+        preset.config,
+        jira="MOB-555",
+        expected_partners=["Uber"],
+    )
+
+    thresholds, _ = cli._evaluate_thresholds(
+        result,
+        expected_partners=["Uber"],
+        max_added=0,
+        max_removed=0,
+    )
+
+    payload = build_canonical_payload(result, thresholds)
+
+    buffer = BytesIO()
+    write_xlsx_report(result, payload, buffer)
+    buffer.seek(0)
+    workbook = load_workbook(filename=buffer, data_only=True)
+
+    assert workbook.sheetnames == ["Summary", "Added", "Removed", "Changed"]
+
+    summary = workbook["Summary"]
+    assert summary.freeze_panes == "A2"
+    assert summary.auto_filter.ref == f"A1:B{summary.max_row}"
+    assert _lookup_summary_value(summary, "Added") == payload["summary"]["added"]
+    assert _lookup_summary_value(summary, "Removed") == payload["summary"]["removed"]
+    assert _lookup_summary_value(summary, "Changed") == payload["summary"]["changed"]
+    assert "DoorDash" in _lookup_summary_value(summary, "Unexpected partners")
+    assert "UNEXPECTED_PARTNER" in _lookup_summary_value(summary, "Threshold violations")
+
+    added = workbook["Added"]
+    assert added.freeze_panes == "A2"
+    assert added.auto_filter.ref.startswith("A1:")
+    header = next(added.iter_rows(min_row=1, max_row=1, values_only=True))
+    expected_headers = ("key", *tuple(preset.config.fields))
+    assert header == expected_headers
+    added_row = next(added.iter_rows(min_row=2, max_row=2, values_only=True))
+    assert added_row[0].startswith("PublicID=EXP-002")
+    partner_column = header.index("Partner")
+    assert added_row[partner_column] == "DoorDash"
+
+    changed = workbook["Changed"]
+    assert changed.freeze_panes == "A2"
+    assert changed.auto_filter.ref.startswith("A1:")
+    changed_rows = list(changed.iter_rows(min_row=2, values_only=True))
+    assert ("PublicID=EXP-001", "Partner", "Uber", "Lyft") in changed_rows
+    assert ("PublicID=EXP-001", "State", "NY", "CA") in changed_rows
+
+    out_dir = tmp_path / "reports" / "run"
+    produced = write_reports(
+        result,
+        out_dir,
+        report_type="xlsx",
+        thresholds=thresholds,
+    )
+
+    json_path = out_dir / "diff.json"
+    xlsx_path = out_dir / f"{out_dir.name}.xlsx"
+
+    assert str(json_path) in produced
+    assert str(xlsx_path) in produced
+    assert all(not path.endswith(".csv") for path in produced)


### PR DESCRIPTION
## Summary
- escape the embedded HTML report JSON payload to guard against `</script>` and line separator issues while keeping inline CSP and window accessors
- add regression coverage ensuring script-tag JSON survives terminator sequences and U+2028/U+2029 characters
- document the hardened embedding behaviour and record the fix in the changelog

## Testing
- make fmt
- make test


------
https://chatgpt.com/codex/tasks/task_e_68e431aca9cc832f83ab03faa89764f5