### PR TITLE
ci: harden release workflow and document GUI packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,18 @@ jobs:
     needs: tests
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             archive: SER-Diff-Linux.zip
             binary_name: ser-diff-gui
-            binary_path: ser-diff-gui
-            pretty_os: Linux
           - os: macos-latest
             archive: SER-Diff-macOS.zip
-            binary_name: "SER Diff"
-            binary_path: "SER Diff.app"
-            pretty_os: macOS
+            binary_name: SER-Diff
           - os: windows-latest
             archive: SER-Diff-Windows.zip
             binary_name: SER-Diff
-            binary_path: SER-Diff.exe
-            pretty_os: Windows
 
     steps:
       - name: Checkout
@@ -68,71 +63,44 @@ jobs:
       - name: Install build dependencies
         run: python -m pip install --upgrade pip && pip install -e .[dev] pyinstaller
 
+      - name: Preflight: ensure GUI script exists
+        shell: bash
+        run: |
+          set -e
+          test -f "src/serdiff/gui_runner.py" || { echo "ERROR: src/serdiff/gui_runner.py not found"; exit 1; }
+          echo "OK: src/serdiff/gui_runner.py present"
+
       - name: Build GUI binary
         shell: bash
         env:
-          SERDIFF_GUI_NAME: ${{ matrix.binary_name }}
-        run: pyinstaller --clean pyinstaller/ser-diff-gui.spec
-
-      - name: Package zip artifact
-        shell: bash
-        env:
           ARCHIVE_NAME: ${{ matrix.archive }}
-          BINARY_PATH: ${{ matrix.binary_path }}
-          PRETTY_OS: ${{ matrix.pretty_os }}
+          BINARY_NAME: ${{ matrix.binary_name }}
         run: |
-          python - <<'PY'
-          import os
-          import pathlib
-          import shutil
-          import textwrap
-          import zipfile
-
-          dist = pathlib.Path("dist")
-          binary_rel = pathlib.Path(os.environ["BINARY_PATH"])
-          binary_source = dist / binary_rel
-          if not binary_source.exists() and not binary_rel.suffix:
-              possible = binary_rel.with_suffix(".app")
-              if (dist / possible).exists():
-                  binary_source = dist / possible
-                  binary_rel = possible
-          if not binary_source.exists():
-              raise SystemExit(f"expected binary at {binary_source}")
-
-          staging = pathlib.Path("release")
-          if staging.exists():
-              shutil.rmtree(staging)
-          staging.mkdir()
-
-          readme = staging / "README_RUN_ME.txt"
-          readme.write_text(
-              textwrap.dedent(
-                  f"""
-                  SER Diff GUI ({os.environ['PRETTY_OS']})
-                  ====================================
-
-                  1. Extract this zip archive.
-                  2. Run the bundled GUI binary to select BEFORE/AFTER XML files.
-                  3. Optional: click "Check Environment" to run ser-diff doctor.
-                  4. Reports are written beneath ~/SER-Diff-Reports/ and the folder opens automatically.
-
-                  Need CLI usage or build instructions? See https://github.com/ser-projects/ser-snapshot-diff-automation#installation
-                  """
-              ).strip(),
-              encoding="utf-8",
-          )
-
-          target = staging / binary_rel.name
-          if binary_source.is_dir():
-              shutil.copytree(binary_source, target)
-          else:
-              shutil.copy2(binary_source, target)
-
-          archive = pathlib.Path(os.environ["ARCHIVE_NAME"])
-          with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as zf:
-              for path in staging.rglob("*"):
-                  zf.write(path, path.relative_to(staging))
-          PY
+          set -e
+          mkdir -p upload
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            pyinstaller --onefile --windowed -n "$BINARY_NAME" src/serdiff/gui_runner.py
+            cp "dist/${BINARY_NAME}.exe" upload/
+            cat <<'EOF_WIN' > upload/README_RUN_ME.txt
+Double-click SER-Diff.exe
+Pick BEFORE/AFTER XML
+EOF_WIN
+            powershell -command "Compress-Archive -Path upload\* -DestinationPath ${ARCHIVE_NAME}"
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            pyinstaller --onefile --windowed -n "$BINARY_NAME" src/serdiff/gui_runner.py
+            cp -R "dist/${BINARY_NAME}.app" upload/
+            cat <<'EOF_MAC' > upload/README_RUN_ME.txt
+Open SER-Diff.app (Gatekeeper may prompt)
+EOF_MAC
+            (cd upload && zip -r "../${ARCHIVE_NAME}" .)
+          else
+            pyinstaller --onefile --windowed -n "$BINARY_NAME" src/serdiff/gui_runner.py
+            cp "dist/${BINARY_NAME}" upload/
+            cat <<'EOF_LINUX' > upload/README_RUN_ME.txt
+./ser-diff-gui
+EOF_LINUX
+            (cd upload && zip -r "../${ARCHIVE_NAME}" .)
+          fi
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,11 @@ All notable changes to this project will be documented in this file.
 - Safely escape embedded JSON in the HTML report to prevent premature `</script>` termination and retain Unicode line separators.
 - GUI now opens the generated primary report (or its folder) reliably and `DiffRunResult` exposes concrete report paths for automation consumers.
 - GUI imports now use absolute `serdiff.` paths so PyInstaller one-file builds run without package-context errors.
+- Release workflow now calls PyInstaller with `src/serdiff/gui_runner.py`, adds a script preflight check, and lets macOS, Windows, and Linux builds finish independently with `fail-fast: false`.
 
 ### Docs
 - README quick-start for the GUI runner and refreshed installation notes covering download/build steps for one-file binaries.
 - Refreshed README-first documentation with installation paths, quick-start guides, single-file report coverage, canonical JSON usage, guardrails, SOP, and troubleshooting guidance aligned to the current CLI.
 - Updated `docs/install.md` for pipx/venv workflows and binary build steps, and introduced `docs/reports.md` covering HTML/XLSX features and JSON extraction tips.
 - Added README and `docs/install.md` sections describing local GUI builds and the release tagging workflow for binary distribution.
+- Documented the stable GUI script path, Gatekeeper guidance, and CI build safeguards (preflight + independent matrix) for the PyInstaller workflow.

--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@
 ## GUI Runner
 
 1. Download the latest "SER Diff" GUI zip for your platform from [GitHub Releases](https://github.com/ser-projects/ser-snapshot-diff-automation/releases).
-2. Extract the archive and double-click the bundled binary (`SER-Diff.exe`, `SER Diff.app`, or `ser-diff-gui`).
+2. Extract the archive and double-click the bundled binary (`SER-Diff.exe`, `SER-Diff.app`, or `ser-diff-gui`).
 3. Choose BEFORE and AFTER XML exports. The Jira ID field is automatically pre-filled if `.serdiff.toml/.yaml/.json` is present in the working directory.
 4. Click **Run Diff**. A timestamped folder beneath `~/SER-Diff-Reports/` is created, the primary report opens directly in your file explorer (with a folder fallback when required), and any guardrail warnings are highlighted in the GUI.
 5. Click **Check Environment** any time to run `ser-diff doctor` and confirm local prerequisites.
+
+> **macOS Gatekeeper:** On the first launch, right-click `SER-Diff.app`, choose **Open**, and acknowledge the unidentified developer prompt.
 
 ### Launch options
 
 - `ser-diff-gui` (installed via `pipx install ser-diff` or `pip install .`).
 - `python -m serdiff.gui_runner` from a virtual environment.
-- One-file binaries built with PyInstaller (`SER-Diff.exe`, `SER Diff.app`, `ser-diff-gui`).
+- One-file binaries built with PyInstaller (`SER-Diff.exe`, `SER-Diff.app`, `ser-diff-gui`).
 
 For build instructions and advanced packaging notes, see [docs/install.md](docs/install.md).
 
@@ -263,7 +265,7 @@ Integrate `ser-diff` into GitHub Actions or similar pipelines. Example excerpt:
 
 Guardrail breaches return exit code `2`. Configure CI to treat `2` as failure while still uploading artifacts for review.
 
-Tagged releases can reuse the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml) to build single-file binaries.
+Tagged releases can reuse the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml) to build single-file binaries. The release job now invokes PyInstaller directly with `src/serdiff/gui_runner.py`, performs a preflight check for the script, and disables matrix fail-fast so Windows, macOS, and Linux builds succeed or fail independently.
 
 ## Standard Change SOP
 
@@ -310,10 +312,10 @@ python -m pip install -e .[dev] pyinstaller
 Then package the Tkinter GUI with PyInstaller:
 
 - **Windows (PowerShell):** `pyinstaller --onefile --windowed -n "SER-Diff" src/serdiff/gui_runner.py`
-- **macOS:** `pyinstaller --onefile --windowed -n "SER Diff.app" src/serdiff/gui_runner.py`
+- **macOS:** `pyinstaller --onefile --windowed -n "SER-Diff" src/serdiff/gui_runner.py`
 - **Linux:** `pyinstaller --onefile --windowed -n "ser-diff-gui" src/serdiff/gui_runner.py`
 
-Artifacts appear under `dist/` ready to zip and share.
+Artifacts appear under `dist/` ready to zip and share (`SER-Diff.exe`, `SER-Diff.app`, and `ser-diff-gui`).
 
 ### Publish release (GUI binaries)
 
@@ -326,7 +328,7 @@ Artifacts appear under `dist/` ready to zip and share.
    git push origin vX.Y.Z
    ```
 
-4. GitHub Actions uploads `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip` to the release. Verify the assets and update README links if the repository location changes.
+4. GitHub Actions uploads `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip` to the release. Each job fails early if `src/serdiff/gui_runner.py` is missing, and the matrix keeps running even if one OS fails. Verify the assets and update README links if the repository location changes.
 
 Optional hooks:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,9 +5,11 @@
 ### Download and run
 
 1. Grab the latest platform zip from the [Releases page](https://github.com/ser-projects/ser-snapshot-diff-automation/releases).
-2. Extract the archive and double-click the binary (`SER-Diff.exe`, `SER Diff.app`, or `ser-diff-gui`).
+2. Extract the archive and double-click the binary (`SER-Diff.exe`, `SER-Diff.app`, or `ser-diff-gui`).
 3. Select BEFORE and AFTER XML files, confirm the optional Jira ticket, and click **Run Diff**. The generated HTML/XLSX report opens automatically (with a folder fallback if the OS cannot launch the file directly).
 4. Use **Check Environment** to run `ser-diff doctor` if you encounter issues.
+
+> **macOS Gatekeeper:** On first launch, right-click `SER-Diff.app`, choose **Open**, and confirm the prompt if macOS warns about an unidentified developer.
 
 ### Build GUI locally with PyInstaller
 
@@ -31,7 +33,7 @@ pyinstaller --onefile --windowed -n "SER-Diff" src/serdiff/gui_runner.py
 #### macOS (Terminal)
 
 ```bash
-pyinstaller --onefile --windowed -n "SER Diff.app" src/serdiff/gui_runner.py
+pyinstaller --onefile --windowed -n "SER-Diff" src/serdiff/gui_runner.py
 ```
 
 #### Linux (Terminal)
@@ -40,7 +42,7 @@ pyinstaller --onefile --windowed -n "SER Diff.app" src/serdiff/gui_runner.py
 pyinstaller --onefile --windowed -n "ser-diff-gui" src/serdiff/gui_runner.py
 ```
 
-PyInstaller places the finished binaries under `dist/`. Zip each platform output for distribution (the GitHub Release workflow names the archives `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip`).
+PyInstaller places the finished binaries under `dist/`. Zip each platform output for distribution (the GitHub Release workflow names the archives `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip`). The CI job invokes PyInstaller directly with `src/serdiff/gui_runner.py`, so keep that path stable—if the script moves, update the workflow and rerun the preflight check locally before tagging.
 
 ## pipx (recommended)
 
@@ -90,12 +92,13 @@ ser-diff doctor
    git push origin vX.Y.Z
    ```
 
-4. GitHub Actions builds and uploads the Windows, macOS, and Linux GUI zips (`SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, `SER-Diff-Linux.zip`) to the release.
+4. GitHub Actions builds and uploads the Windows, macOS, and Linux GUI zips (`SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, `SER-Diff-Linux.zip`) to the release. Each matrix job sets `fail-fast: false`, so other platforms continue even if one build fails.
 5. Validate the assets on the Releases page and update documentation links if the organization or repository name changes.
 
 ### Troubleshooting
 
 - *ImportError: attempted relative import with no known parent package* → rebuild after ensuring all GUI imports use the `serdiff.` prefix (absolute imports).
 - *Windows SmartScreen warning* → select **More info → Run anyway** until code signing is available.
+- *ERROR: src/serdiff/gui_runner.py not found* during CI → verify the script exists at that path and re-run the workflow; the preflight step intentionally fails fast while the matrix keeps running for other OS targets.
 
 Release automation details live in [`.github/workflows/release.yml`](../.github/workflows/release.yml).


### PR DESCRIPTION
## Summary
- call PyInstaller directly with src/serdiff/gui_runner.py in the release workflow, add a preflight script check, and keep each OS build running by disabling matrix fail-fast
- standardize binary names across platforms and package OS-specific zips with README instructions while preserving release uploads
- refresh README, install docs, and changelog to highlight the stable GUI script path, Gatekeeper notes, and CI safeguards

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e59ee3a0fc832f8330acd35eeea25f