### PR TITLE
Fix release preflight stale path detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release GUI & CLI Binaries
 
 on:
   push:
@@ -54,14 +54,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev] pyinstaller
 
-      - name: Preflight: verify entrypoint scripts & guard stale refs
+      - name: "Preflight: verify entrypoint scripts & guard stale refs"
         shell: bash
         run: |
           set -e
           test -f "src/serdiff/gui_runner.py" || { echo "::error::Missing src/serdiff/gui_runner.py"; exit 1; }
           test -f "src/serdiff/cli.py" || { echo "::error::Missing src/serdiff/cli.py"; exit 1; }
-          if git grep -n "pyinstaller/src/serdiff/gui_runner.py" -- . ; then
-            echo "::error::Stale path 'pyinstaller/src/serdiff/gui_runner.py' found above. Fix references."
+          stale_path='pyinstaller/src/serdiff/'"gui_runner.py"
+          if git grep -n "$stale_path" -- . ; then
+            echo "::error::Stale path '$stale_path' found above. Fix references."
             exit 1
           fi
           echo "Entrypoint scripts OK."
@@ -71,7 +72,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          rm -rf build dist
+          rm -rf build dist upload
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             pyinstaller --onefile --windowed -n "SER-Diff" src/serdiff/gui_runner.py
             pyinstaller --onefile --console -n "ser-diff" src/serdiff/cli.py
@@ -79,7 +80,7 @@ jobs:
             mkdir -p upload/win
             cp dist/SER-Diff.exe upload/win/
             cp dist/ser-diff.exe upload/win/
-            printf "GUI: SER-Diff.exe\nCLI: ser-diff.exe\n" > upload/win/README_RUN_ME.txt
+            printf "Double-click SER-Diff.exe (GUI). Put XMLs in exports/. Reports appear in reports/.\nCLI: ser-diff.exe (advanced).\n" > upload/win/README_RUN_ME.txt
             powershell -command "Compress-Archive -Path upload\\win\\* -DestinationPath SER-Diff-Windows.zip"
             echo "archive=SER-Diff-Windows.zip" >> "$GITHUB_OUTPUT"
 
@@ -90,7 +91,7 @@ jobs:
             mkdir -p upload/mac
             cp -R "dist/SER-Diff.app" upload/mac/
             cp "dist/ser-diff" upload/mac/
-            printf "GUI: SER-Diff.app (Gatekeeper may prompt)\nCLI: ./ser-diff\n" > upload/mac/README_RUN_ME.txt
+            printf "Double-click SER-Diff.app (GUI). Put XMLs in exports/. Reports appear in reports/.\nCLI: ./ser-diff (advanced).\n" > upload/mac/README_RUN_ME.txt
             (cd upload/mac && zip -r ../../SER-Diff-macOS.zip .)
             echo "archive=SER-Diff-macOS.zip" >> "$GITHUB_OUTPUT"
 
@@ -101,12 +102,113 @@ jobs:
             mkdir -p upload/linux
             cp dist/ser-diff-gui upload/linux/
             cp dist/ser-diff upload/linux/
-            printf "GUI: ./ser-diff-gui\nCLI: ./ser-diff\n" > upload/linux/README_RUN_ME.txt
+            printf "Double-click (or run ./ser-diff-gui) for the GUI. Put XMLs in exports/. Reports appear in reports/.\nCLI: ./ser-diff (advanced).\n" > upload/linux/README_RUN_ME.txt
             (cd upload/linux && zip -r ../../SER-Diff-Linux.zip .)
             echo "archive=SER-Diff-Linux.zip" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Verify packaged archive contents
+        shell: bash
+        env:
+          ARCHIVE: ${{ steps.package.outputs.archive }}
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import zipfile
+
+          archive = os.environ["ARCHIVE"]
+          runner_os = os.environ.get("RUNNER_OS")
+
+          if not archive:
+              raise SystemExit("Archive path is empty")
+
+          expected = {
+              "Windows": {"SER-Diff.exe", "ser-diff.exe", "README_RUN_ME.txt"},
+              "macOS": {"SER-Diff.app", "ser-diff", "README_RUN_ME.txt"},
+              "Linux": {"ser-diff-gui", "ser-diff", "README_RUN_ME.txt"},
+          }.get(runner_os)
+
+          if expected is None:
+              raise SystemExit(f"Unexpected RUNNER_OS={runner_os!r}")
+
+          def normalize(name: str) -> str:
+              if name.endswith("/"):
+                  name = name[:-1]
+              if name.startswith("./"):
+                  name = name[2:]
+              return name
+
+          with zipfile.ZipFile(archive) as zf:
+              entries = {normalize(name).split("/", 1)[0] for name in zf.namelist()}
+
+          missing = sorted(expected - entries)
+          if missing:
+              raise SystemExit(
+                  f"Archive {archive} on {runner_os} missing expected entries: {', '.join(missing)}"
+              )
+
+          print(f"Verified {archive}: contains {sorted(entries)}")
+          PY
+
+      - name: Smoke test GUI binary (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib
+          import subprocess
+          import time
+
+          exe = pathlib.Path("dist") / "SER-Diff.exe"
+          if not exe.exists():
+              raise SystemExit(f"Missing GUI binary at {exe}")
+
+          proc = subprocess.Popen([str(exe)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+          time.sleep(2)
+          if proc.poll() is None:
+              proc.terminate()
+              try:
+                  proc.wait(timeout=5)
+              except subprocess.TimeoutExpired:
+                  proc.kill()
+                  proc.wait(timeout=5)
+
+          stdout, stderr = proc.communicate()
+          combined = (stdout + stderr).decode("utf-8", errors="ignore")
+          needle = "ser-diff: error: the following arguments are required"
+          if needle in combined:
+              raise SystemExit("GUI binary printed CLI usage output; expected quiet launch")
+          PY
+
+      - name: Smoke test CLI usage
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import subprocess
+
+          if os.environ.get("RUNNER_OS") == "Windows":
+              exe = pathlib.Path("dist") / "ser-diff.exe"
+          else:
+              exe = pathlib.Path("dist") / "ser-diff"
+
+          if not exe.exists():
+              raise SystemExit(f"Missing CLI binary at {exe}")
+
+          result = subprocess.run([str(exe)], capture_output=True, text=True)
+          combined = (result.stdout or "") + (result.stderr or "")
+          needle = "ser-diff: error: the following arguments are required"
+          if result.returncode == 0:
+              raise SystemExit("CLI should emit usage error when no arguments are provided")
+          if needle not in combined:
+              raise SystemExit("CLI usage output missing expected argparse message")
+          PY
 
       - name: Upload assets to Release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.package.outputs.archive }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - GUI now opens the generated primary report (or its folder) reliably and `DiffRunResult` exposes concrete report paths for automation consumers.
 - GUI imports now use absolute `serdiff.` paths so PyInstaller one-file builds run without package-context errors.
 - ci(release): fix PyInstaller commands to use GUI/CLI script entrypoints, add preflight guards, and keep the matrix resilient.
+- ci(release): add GUI smoke check; include README in ZIP.
 
 ### Docs
 - README quick-start for the GUI runner and refreshed installation notes covering download/build steps for one-file binaries.
@@ -35,3 +36,4 @@ All notable changes to this project will be documented in this file.
 - Updated `docs/install.md` for pipx/venv workflows and binary build steps, and introduced `docs/reports.md` covering HTML/XLSX features and JSON extraction tips.
 - Added README and `docs/install.md` sections describing local GUI builds and the release tagging workflow for binary distribution.
 - Documented the stable GUI script path, Gatekeeper guidance, and CI build safeguards (preflight + independent matrix) for the PyInstaller workflow.
+- docs(release): package GUI+CLI per OS; default instructions target GUI.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
 
 ## GUI Runner
 
-1. Download the latest "SER Diff" GUI zip for your platform from [GitHub Releases](https://github.com/ser-projects/ser-snapshot-diff-automation/releases).
-2. Extract the archive and double-click the bundled binary (`SER-Diff.exe`, `SER-Diff.app`, or `ser-diff-gui`).
-3. Choose BEFORE and AFTER XML exports. The Jira ID field is automatically pre-filled if `.serdiff.toml/.yaml/.json` is present in the working directory.
-4. Click **Run Diff**. A timestamped folder beneath `~/SER-Diff-Reports/` is created, the primary report opens directly in your file explorer (with a folder fallback when required), and any guardrail warnings are highlighted in the GUI.
+1. Download the platform ZIP (Windows/macOS/Linux) from [GitHub Releases](https://github.com/ser-projects/ser-snapshot-diff-automation/releases).
+2. Extract the archive and double-click **SER-Diff** (`SER-Diff.exe` on Windows, `SER-Diff.app` on macOS, or run `./ser-diff-gui` on Linux). Each bundle also includes the CLI companion (`ser-diff.exe` or `ser-diff`) plus a README with quick-start details.
+3. Place your BEFORE and AFTER XML exports inside the `exports/` folder next to the binaries. Reports are written to `reports/`.
+4. In the app, pick BEFORE/AFTER exports, tweak options as needed, and click **Run Diff**. A timestamped folder beneath `~/SER-Diff-Reports/` is created, the primary report opens directly in your file explorer (with a folder fallback when required), and any guardrail warnings are highlighted in the GUI.
 5. Click **Check Environment** any time to run `ser-diff doctor` and confirm local prerequisites.
 
 > **macOS Gatekeeper:** On the first launch, right-click `SER-Diff.app`, choose **Open**, and acknowledge the unidentified developer prompt.
@@ -37,6 +37,8 @@
 - One-file binaries built with PyInstaller (`SER-Diff.exe`, `SER-Diff.app`, `ser-diff-gui`).
 
 For build instructions and advanced packaging notes, see [docs/install.md](docs/install.md).
+
+> **Troubleshooting:** If you see a console window with argparse usage text, you launched the CLI (`ser-diff.exe`/`ser-diff`). Close it and double-click `SER-Diff.exe`/`SER-Diff.app` (or run `./ser-diff-gui`) for the GUI.
 
 ## Installation
 
@@ -265,7 +267,7 @@ Integrate `ser-diff` into GitHub Actions or similar pipelines. Example excerpt:
 
 Guardrail breaches return exit code `2`. Configure CI to treat `2` as failure while still uploading artifacts for review.
 
-Tagged releases can reuse the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml) to build single-file binaries. The release job now invokes PyInstaller directly with `src/serdiff/gui_runner.py`, performs a preflight check for the script, and disables matrix fail-fast so Windows, macOS, and Linux builds succeed or fail independently.
+Tagged releases can reuse the workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml) to build single-file binaries. The release job now invokes PyInstaller directly with `src/serdiff/gui_runner.py`, performs a preflight check for the script, disables matrix fail-fast so Windows, macOS, and Linux builds succeed or fail independently, and zips the GUI + CLI pair for each platform alongside a `README_RUN_ME.txt` helper.
 
 ## Standard Change SOP
 
@@ -293,6 +295,7 @@ The HTML report embeds canonical JSON safely: `</` sequences are escaped and Uni
 - **Duplicate keys**: Auto Mode extends composite keys; review `ser-diff explain` output for candidate fields.
 - **Unexpected namespaces**: combine `--strip-ns` with explicit `--record-localname` or configure via `.serdiff.toml`.
 - **Windows paths**: quote paths with spaces and prefer PowerShell for better UTF-8 handling; Git Bash works with forward slashes.
+- **`ImportError: attempted relative import with no known parent package`**: ensure you launched the CLI from the packaged zip (contains the fixed absolute imports) or upgrade to the latest release.
 
 ## Development
 
@@ -328,7 +331,7 @@ Artifacts appear under `dist/` ready to zip and share (`SER-Diff.exe`, `SER-Diff
    git push origin vX.Y.Z
    ```
 
-4. GitHub Actions uploads `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip` to the release. Each job fails early if `src/serdiff/gui_runner.py` is missing, and the matrix keeps running even if one OS fails. Verify the assets and update README links if the repository location changes.
+4. GitHub Actions uploads `SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, and `SER-Diff-Linux.zip` to the release. Each archive contains the GUI binary, CLI binary, and `README_RUN_ME.txt`. Jobs fail early if `src/serdiff/gui_runner.py` is missing, and the matrix keeps running even if one OS fails. Verify the assets and update README links if the repository location changes.
 
 Optional hooks:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -54,7 +54,7 @@ pyinstaller --onefile --console -n "ser-diff" src/serdiff/cli.py
 
 On Windows the output is `dist/ser-diff.exe`; on macOS/Linux it is `dist/ser-diff`. Package it alongside the GUI binary for releases.
 
-The Release workflow now fails early if it detects missing entrypoint scripts or the stale `pyinstaller/src/serdiff/gui_runner.py` path anywhere in the repository, ensuring both binaries continue to build from `src/serdiff/gui_runner.py` and `src/serdiff/cli.py`.
+The Release workflow now fails early if it detects missing entrypoint scripts or references to the old PyInstaller-specific GUI runner location, ensuring both binaries continue to build from `src/serdiff/gui_runner.py` and `src/serdiff/cli.py`.
 
 ## pipx (recommended)
 
@@ -104,7 +104,7 @@ ser-diff doctor
    git push origin vX.Y.Z
    ```
 
-4. GitHub Actions builds and uploads the Windows, macOS, and Linux zips—each bundle now contains both GUI (`SER-Diff.exe`/`.app`/`ser-diff-gui`) and CLI (`ser-diff(.exe)`) binaries alongside a README (`SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, `SER-Diff-Linux.zip`). Each matrix job sets `fail-fast: false`, so other platforms continue even if one build fails. The preflight guard blocks the run if the entrypoint scripts are missing or the deprecated `pyinstaller/src/serdiff/gui_runner.py` reference resurfaces, ensuring the matrix keeps building against `src/serdiff/gui_runner.py` and `src/serdiff/cli.py`.
+4. GitHub Actions builds and uploads the Windows, macOS, and Linux zips—each bundle now contains both GUI (`SER-Diff.exe`/`.app`/`ser-diff-gui`) and CLI (`ser-diff(.exe)`) binaries alongside a README (`SER-Diff-Windows.zip`, `SER-Diff-macOS.zip`, `SER-Diff-Linux.zip`). Each matrix job sets `fail-fast: false`, so other platforms continue even if one build fails. The preflight guard blocks the run if the entrypoint scripts are missing or if any files reintroduce the deprecated PyInstaller path for the GUI runner, ensuring the matrix keeps building against `src/serdiff/gui_runner.py` and `src/serdiff/cli.py`.
 5. Validate the assets on the Releases page and update documentation links if the organization or repository name changes.
 
 ### Troubleshooting

--- a/src/serdiff/cli.py
+++ b/src/serdiff/cli.py
@@ -12,11 +12,11 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import __version__
-from .config import LoadedConfig, load_config
-from .detect import ROW_INDEX_FIELD, detect_schema, infer_fields, infer_key_fields, probe_xml
-from .diff import DiffConfig, DiffResult, diff_files, write_reports
-from .presets import get_preset
+from serdiff import __version__
+from serdiff.config import LoadedConfig, load_config
+from serdiff.detect import ROW_INDEX_FIELD, detect_schema, infer_fields, infer_key_fields, probe_xml
+from serdiff.diff import DiffConfig, DiffResult, diff_files, write_reports
+from serdiff.presets import get_preset
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1

--- a/src/serdiff/diff.py
+++ b/src/serdiff/diff.py
@@ -11,10 +11,10 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-from . import __version__
-from .detect import ROW_INDEX_FIELD
-from .report_html import render_html_report
-from .report_xlsx import write_xlsx_report
+from serdiff import __version__
+from serdiff.detect import ROW_INDEX_FIELD
+from serdiff.report_html import render_html_report
+from serdiff.report_xlsx import write_xlsx_report
 
 
 def _local_name(tag: str | None) -> str:

--- a/src/serdiff/presets.py
+++ b/src/serdiff/presets.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .detect import ROW_INDEX_FIELD
-from .diff import DiffConfig
+from serdiff.detect import ROW_INDEX_FIELD
+from serdiff.diff import DiffConfig
 
 
 @dataclass(frozen=True)

--- a/src/serdiff/report_html.py
+++ b/src/serdiff/report_html.py
@@ -7,7 +7,7 @@ import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from .diff import DiffResult
+    from serdiff.diff import DiffResult
 
 
 def safe_json_for_script(payload: dict[str, object]) -> str:

--- a/src/serdiff/report_xlsx.py
+++ b/src/serdiff/report_xlsx.py
@@ -10,7 +10,7 @@ from openpyxl import Workbook
 from openpyxl.utils import get_column_letter
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
-    from .diff import DiffResult
+    from serdiff.diff import DiffResult
 
 
 def _append_rows(ws, rows: Iterable[tuple[Any, ...]]) -> None:

--- a/tests/test_cli_import_smoke.py
+++ b/tests/test_cli_import_smoke.py
@@ -1,0 +1,7 @@
+"""Smoke tests for CLI importability."""
+
+
+def test_cli_import_smoke() -> None:
+    """Importing the CLI module should succeed without relative imports."""
+
+    __import__("serdiff.cli")

--- a/tests/test_gui_import_headless.py
+++ b/tests/test_gui_import_headless.py
@@ -1,6 +1,8 @@
-"""Smoke test that the GUI module imports headlessly."""
+"""Ensure the GUI entrypoint imports without side effects."""
 
 
-def test_gui_import_smoke(monkeypatch):
+def test_gui_import_smoke(monkeypatch) -> None:  # pragma: no cover - import smoke
+    """Importing the GUI runner should succeed even in headless mode."""
+
     monkeypatch.setenv("SERDIFF_GUI_HEADLESS", "1")
     __import__("serdiff.gui_runner")


### PR DESCRIPTION
## Summary
- update the release preflight guard to compute the stale PyInstaller path at runtime so the workflow no longer triggers on its own safeguard
- refresh the installation guide to describe the guardrail without reintroducing the deprecated path string

## Testing
- ruff check .
- black --check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6868a9dc0832faf59441f21bab2ee